### PR TITLE
Add issue templates, update PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,39 @@
+---
+name: '🐛 Bug Report'
+about: Something isn't working
+labels: "Type: Bug 🐛"
+---
+
+# Issue summary
+
+Write a short description of the issue here ↓
+
+
+## Expected behavior
+
+What do you think should happen?
+
+
+## Actual behavior
+
+What actually happens?
+
+Tip: include an error message (in a `<details></details>` tag) if your issue is related to an error
+
+
+## Steps to reproduce the problem
+
+1.
+1.
+1.
+
+## Reduced test case
+
+The best way to get your bug fixed is to provide a [reduced test case](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Reducing_testcases).
+
+
+---
+
+## Checklist
+
+- [ ] I have described this issue in a way that is actionable (if possible)

--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT.md
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT.md
@@ -1,0 +1,26 @@
+---
+name: '📈 Enhancement'
+about: Enhancement to our codebase that isn't a adding or changing a feature
+labels: "Type: Enhancement 📈" 
+---
+
+## Overview/summary
+
+...
+
+## Motivation
+
+> What inspired this enhancement?
+
+...
+
+### Area
+
+- [ ] Add any relevant `Area: <area>` labels to this issue
+
+
+---
+
+## Checklist
+
+- [ ] I have described this enhancement in a way that is actionable (if possible)

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,30 @@
+---
+name: '🙌 Feature Request'
+about: Suggest a new feature, or changes to an existing one
+labels: "Type: Feature Request :raised_hands:" 
+---
+
+## Overview
+
+...
+
+## Type
+
+- [ ] New feature
+- [ ] Changes to existing features
+
+## Motivation
+
+> What inspired this feature request? What problems were you facing?
+
+...
+
+### Area
+
+- [ ] Add any relevant `Area: <area>` labels to this issue
+
+---
+
+## Checklist
+
+- [ ] I have described this feature request in a way that is actionable (if possible)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,5 +18,17 @@ Fixes #0000 <!-- link to issue if one exists -->
 
 <!--
   Summary of the changes committed.
-  Before / after screenshots appreciated for UI changes.
+  Before / after screenshots appreciated for UI changes, if applicable.
 -->
+
+## Type of change
+
+- [ ] Patch: Bug (non-breaking change which fixes an issue)
+- [ ] Minor: New feature (non-breaking change which adds functionality)
+- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+
+## Checklist
+
+- [ ] I have added a changelog entry, prefixed by the type of change noted above
+- [ ] I have added/updated tests for this change


### PR DESCRIPTION
### Add issue templates, update PR template

### WHY are these changes introduced?

Leverage pre-established templates

### WHAT is this pull request doing?

Add issue templates and updated PR template (duplicated from `koa-shopify-auth`)

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] Not applicable