### PR TITLE
Added ability to retry requests in HTTP client

### DIFF
--- a/src/clients/test/test_helper.ts
+++ b/src/clients/test/test_helper.ts
@@ -5,9 +5,11 @@ export function assertHttpRequest(
   domain: string,
   path: string,
   headers: Record<string, unknown> = {},
-  data: string | null = null
+  data: string | null = null,
+  retries: number | null = null
 ): void {
-  expect(fetchMock).toBeCalledWith(
+  const expectResult = expect(fetchMock);
+  expectResult.toBeCalledWith(
     `https://${domain}${path}`,
     expect.objectContaining({
       method: method,
@@ -15,4 +17,8 @@ export function assertHttpRequest(
       body: data,
     })
   );
+
+  if (retries !== null) {
+    expectResult.toHaveBeenCalledTimes(retries);
+  }
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -5,24 +5,26 @@ class InvalidHmacError extends ShopifyError {}
 class SafeCompareError extends ShopifyError {}
 
 class HttpRequestError extends ShopifyError {}
-class HttpRetriableError extends ShopifyError {}
-class HttpInternalError extends HttpRetriableError {}
-class HttpThrottlingError extends HttpRetriableError {}
+class HttpMaxRetriesError extends ShopifyError {}
 class HttpResponseError extends ShopifyError {
-  public constructor(message: string, readonly code: number) {
+  public constructor(message: string, readonly code: number, readonly statusText: string) {
     super(message);
   }
 }
+class HttpRetriableError extends ShopifyError {}
+class HttpInternalError extends HttpRetriableError {}
+class HttpThrottlingError extends HttpRetriableError {}
 
 const ShopifyErrors = {
   ShopifyError,
   InvalidHmacError,
   SafeCompareError,
   HttpRequestError,
+  HttpMaxRetriesError,
+  HttpResponseError,
   HttpRetriableError,
   HttpInternalError,
   HttpThrottlingError,
-  HttpResponseError,
 };
 
 export default ShopifyErrors;

--- a/src/test/test_helper.ts
+++ b/src/test/test_helper.ts
@@ -1,8 +1,8 @@
+import { enableFetchMocks } from 'jest-fetch-mock';
+enableFetchMocks();
+
 import { Context } from '../context';
 import { ApiVersion } from '../types';
-import fetchMock from  'jest-fetch-mock';
-
-fetchMock.enableMocks();
 
 beforeEach(() => {
   // We want to reset the Context object on every run so that tests start with a consistent state
@@ -14,5 +14,5 @@ beforeEach(() => {
     API_VERSION: ApiVersion.Unstable,
   });
 
-  fetchMock.resetMocks();
+  fetchMock.mockRestore();
 });


### PR DESCRIPTION
### WHY are these changes introduced?

In some cases, HTTP requests may fail due to circumstances that don't necessarily mean they were invalid - for instance when the API throttles an app's requests or when they hit a 500 error on the server. This PR adds the ability to automatically retry requests if they fail for a 'retriable' reason.

### WHAT is this pull request doing?

We now test the outcome of the request to see if it hit a `429` or `5xx` HTTP error, which in theory may work on a retry. In those cases, the request will be slept for 1s and then retried. If the maximum number of retries is exceeded, a specific exception is thrown with the last error message in it.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added/updated tests for this change
