### PR TITLE
Add API version parameter to REST client

### DIFF
--- a/src/clients/rest/rest_client.ts
+++ b/src/clients/rest/rest_client.ts
@@ -1,3 +1,4 @@
+import { Context } from '../../context';
 import { ShopifyHeader } from '../../types';
 import { HttpClient, RequestParams } from '../http_client';
 
@@ -19,6 +20,6 @@ export class RestClient extends HttpClient {
   }
 
   private getRestPath(path: string): string {
-    return `/admin/${path}.json`;
+    return `/admin/api/${Context.API_VERSION}/${path}.json`;
   }
 }

--- a/src/clients/rest/test/rest_client.test.ts
+++ b/src/clients/rest/test/rest_client.test.ts
@@ -20,7 +20,7 @@ describe("REST client", () => {
     fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
     await expect(client.get('products')).resolves.toEqual(successResponse);
-    assertHttpRequest('GET', domain, '/admin/products.json');
+    assertHttpRequest('GET', domain, '/admin/api/unstable/products.json');
   });
 
   it("can make POST request", async () => {
@@ -34,7 +34,7 @@ describe("REST client", () => {
     };
 
     await expect(client.post('products', postData)).resolves.toEqual(successResponse);
-    assertHttpRequest('POST', domain, '/admin/products.json', {}, postData);
+    assertHttpRequest('POST', domain, '/admin/api/unstable/products.json', {}, postData);
   });
 
   it("can make PUT request", async () => {
@@ -48,7 +48,7 @@ describe("REST client", () => {
     };
 
     await expect(client.put('products/123', postData)).resolves.toEqual(successResponse);
-    assertHttpRequest('PUT', domain, '/admin/products/123.json', {}, postData);
+    assertHttpRequest('PUT', domain, '/admin/api/unstable/products/123.json', {}, postData);
   });
 
   it("can make DELETE request", async () => {
@@ -57,7 +57,7 @@ describe("REST client", () => {
     fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
     await expect(client.delete('products/123')).resolves.toEqual(successResponse);
-    assertHttpRequest('DELETE', domain, '/admin/products/123.json');
+    assertHttpRequest('DELETE', domain, '/admin/api/unstable/products/123.json');
   });
 
   it("merges custom headers with the default ones", async () => {
@@ -72,6 +72,6 @@ describe("REST client", () => {
     await expect(client.get('products', customHeaders)).resolves.toEqual(successResponse);
 
     customHeaders[ShopifyHeader.AccessToken] = 'dummy-token';
-    assertHttpRequest('GET', domain, '/admin/products.json', customHeaders);
+    assertHttpRequest('GET', domain, '/admin/api/unstable/products.json', customHeaders);
   });
 });

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,6 @@
 import ShopifyErrors from './error';
 import { Session, SessionStorage, MemorySessionStorage } from './auth/session';
-import { ContextParams } from './types';
+import { ApiVersion, ContextParams } from './types';
 
 interface ContextInterface extends ContextParams {
   SESSION_STORAGE: SessionStorage,
@@ -39,6 +39,7 @@ const Context: ContextInterface = {
   API_SECRET_KEY: '',
   SCOPES: [],
   HOST_NAME: '',
+  API_VERSION: ApiVersion.Unstable,
   SESSION_STORAGE: new MemorySessionStorage(),
 
   initialize(params: ContextParams): void {
@@ -58,13 +59,16 @@ const Context: ContextInterface = {
     }
 
     if (missing.length) {
-      throw new ShopifyErrors.ShopifyError(`Cannot initialize Shopify App Dev Kit. Missing values for: ${missing.join(', ')}`);
+      throw new ShopifyErrors.ShopifyError(
+        `Cannot initialize Shopify App Dev Kit. Missing values for: ${missing.join(', ')}`
+      );
     }
 
     this.API_KEY = params.API_KEY;
     this.API_SECRET_KEY = params.API_SECRET_KEY;
     this.SCOPES = params.SCOPES;
     this.HOST_NAME = params.HOST_NAME;
+    this.API_VERSION = params.API_VERSION;
 
     if (params.SESSION_STORAGE) {
       this.SESSION_STORAGE = params.SESSION_STORAGE;

--- a/src/test/context.test.ts
+++ b/src/test/context.test.ts
@@ -2,114 +2,139 @@ import './test_helper';
 
 import ShopifyErrors from '../error';
 import { Context } from '../context';
-import { ContextParams } from '../types';
+import { ApiVersion, ContextParams } from '../types';
 import { CustomSessionStorage, Session } from '../auth/session';
 
-test("can initialize and update context", () => {
-  Context.initialize(
-    {
-      API_KEY: 'api_key',
-      API_SECRET_KEY: 'api_secret_key',
-      SCOPES: ['do_one_thing', 'do_something_else'],
-      HOST_NAME: 'host_name',
+const validParams: ContextParams = {
+  API_KEY: 'api_key',
+  API_SECRET_KEY: 'secret_key',
+  SCOPES: ['scope'],
+  HOST_NAME: 'host_name',
+  API_VERSION: ApiVersion.Unstable,
+};
+
+const originalWarn = console.warn;
+
+describe("Context object", () => {
+  afterEach(() => {
+    console.warn = originalWarn;
+  });
+
+  it("can initialize and update context", () => {
+    Context.initialize(validParams);
+
+    expect(Context.API_KEY).toEqual(validParams.API_KEY);
+    expect(Context.API_SECRET_KEY).toEqual(validParams.API_SECRET_KEY);
+    expect(Context.SCOPES).toEqual(validParams.SCOPES);
+    expect(Context.HOST_NAME).toEqual(validParams.HOST_NAME);
+  });
+
+  it("can't initialize with empty values", () => {
+    let invalid: ContextParams = Object.assign({}, validParams);
+    invalid.API_KEY = '';
+    try {
+      Context.initialize(invalid);
+      fail('Initializing without API_KEY did not throw an exception');
     }
-  );
-
-  expect(Context.API_KEY).toEqual('api_key');
-  expect(Context.API_SECRET_KEY).toEqual('api_secret_key');
-  expect(Context.SCOPES).toEqual(['do_one_thing', 'do_something_else']);
-  expect(Context.HOST_NAME).toEqual('host_name');
-});
-
-test("can't initialize with empty values", () => {
-  const valid: ContextParams = {
-    API_KEY: 'api_key',
-    API_SECRET_KEY: 'secret_key',
-    SCOPES: ['scope'],
-    HOST_NAME: 'host_name',
-  };
-
-  let invalid: ContextParams = Object.assign({}, valid);
-  invalid.API_KEY = '';
-  expect(() => Context.initialize(invalid)).toThrow(ShopifyErrors.ShopifyError);
-
-  invalid = Object.assign({}, valid);
-  invalid.API_SECRET_KEY = '';
-  expect(() => Context.initialize(invalid)).toThrow(ShopifyErrors.ShopifyError);
-
-  invalid = Object.assign({}, valid);
-  invalid.SCOPES = [];
-  expect(() => Context.initialize(invalid)).toThrow(ShopifyErrors.ShopifyError);
-
-  invalid = Object.assign({}, valid);
-  invalid.HOST_NAME = '';
-  expect(() => Context.initialize(invalid)).toThrow(ShopifyErrors.ShopifyError);
-
-  const empty: ContextParams = {
-    API_KEY: '',
-    API_SECRET_KEY: '',
-    SCOPES: [],
-    HOST_NAME: '',
-  };
-  expect(() => Context.initialize(empty)).toThrow(ShopifyErrors.ShopifyError);
-});
-
-test("can store, load and delete memory sessions by default", async () => {
-  Context.initialize(
-    {
-      API_KEY: 'api_key',
-      API_SECRET_KEY: 'api_secret_key',
-      SCOPES: ['do_one_thing', 'do_something_else'],
-      HOST_NAME: 'host_name',
+    catch (e) {
+      expect(e).toBeInstanceOf(ShopifyErrors.ShopifyError);
+      expect(e.message).toContain('Missing values for: API_KEY');
     }
-  );
 
-  const sessionId = 'test_session';
-  const session = new Session(sessionId, (new Date()).getTime() + 86400000);
+    invalid = Object.assign({}, validParams);
+    invalid.API_SECRET_KEY = '';
+    try {
+      Context.initialize(invalid);
+      fail('Initializing without API_SECRET_KEY did not throw an exception');
+    }
+    catch (e) {
+      expect(e).toBeInstanceOf(ShopifyErrors.ShopifyError);
+      expect(e.message).toContain('Missing values for: API_SECRET_KEY');
+    }
 
-  await expect(Context.storeSession(session)).resolves.toEqual(true);
-  await expect(Context.loadSession(sessionId)).resolves.toEqual(session);
-  await expect(Context.deleteSession(sessionId)).resolves.toEqual(true);
-});
+    invalid = Object.assign({}, validParams);
+    invalid.SCOPES = [];
+    try {
+      Context.initialize(invalid);
+      fail('Initializing without SCOPES did not throw an exception');
+    }
+    catch (e) {
+      expect(e).toBeInstanceOf(ShopifyErrors.ShopifyError);
+      expect(e.message).toContain('Missing values for: SCOPES');
+    }
 
-test("can store, load and delete custom storage sessions", async () => {
-  const sessionId = 'test_session';
-  const session = new Session(sessionId, (new Date()).getTime() + 86400000);
+    invalid = Object.assign({}, validParams);
+    invalid.HOST_NAME = '';
+    try {
+      Context.initialize(invalid);
+      fail('Initializing without HOST_NAME did not throw an exception');
+    }
+    catch (e) {
+      expect(e).toBeInstanceOf(ShopifyErrors.ShopifyError);
+      expect(e.message).toContain('Missing values for: HOST_NAME');
+    }
 
-  let store_called = false;
-  let load_called = false;
-  let delete_called = false;
-  const storage = new CustomSessionStorage(
-    () => {
-      store_called = true;
-      return true;
-    },
-    () => {
-      load_called = true;
-      return session;
-    },
-    () => {
-      delete_called = true;
-      return true;
-    },
-  );
+    const empty: ContextParams = {
+      API_KEY: '',
+      API_SECRET_KEY: '',
+      SCOPES: [],
+      HOST_NAME: '',
+      API_VERSION: ApiVersion.Unstable,
+    };
+    expect(() => Context.initialize(empty)).toThrow(ShopifyErrors.ShopifyError);
+  });
 
-  Context.initialize(
-    {
-      API_KEY: 'api_key',
-      API_SECRET_KEY: 'api_secret_key',
-      SCOPES: ['do_one_thing', 'do_something_else'],
-      HOST_NAME: 'host_name',
-      SESSION_STORAGE: storage,
-    },
-  );
+  it("can store, load and delete memory sessions by default", async () => {
+    Context.initialize(validParams);
 
-  await expect(Context.storeSession(session)).resolves.toEqual(true);
-  expect(store_called).toBe(true);
+    const sessionId = 'test_session';
+    const session = new Session(sessionId, (new Date()).getTime() + 86400000);
 
-  await expect(Context.loadSession(sessionId)).resolves.toEqual(session);
-  expect(load_called).toBe(true);
+    await expect(Context.storeSession(session)).resolves.toEqual(true);
+    await expect(Context.loadSession(sessionId)).resolves.toEqual(session);
+    await expect(Context.deleteSession(sessionId)).resolves.toEqual(true);
+  });
 
-  await expect(Context.deleteSession(sessionId)).resolves.toEqual(true);
-  expect(delete_called).toBe(true);
+  it("can store, load and delete custom storage sessions", async () => {
+    const sessionId = 'test_session';
+    const session = new Session(sessionId, (new Date()).getTime() + 86400000);
+
+    let store_called = false;
+    let load_called = false;
+    let delete_called = false;
+    const storage = new CustomSessionStorage(
+      () => {
+        store_called = true;
+        return true;
+      },
+      () => {
+        load_called = true;
+        return session;
+      },
+      () => {
+        delete_called = true;
+        return true;
+      },
+    );
+
+    Context.initialize(
+      {
+        API_KEY: 'api_key',
+        API_SECRET_KEY: 'api_secret_key',
+        SCOPES: ['do_one_thing', 'do_something_else'],
+        HOST_NAME: 'host_name',
+        API_VERSION: ApiVersion.Unstable,
+        SESSION_STORAGE: storage,
+      },
+    );
+
+    await expect(Context.storeSession(session)).resolves.toEqual(true);
+    expect(store_called).toBe(true);
+
+    await expect(Context.loadSession(sessionId)).resolves.toEqual(session);
+    expect(load_called).toBe(true);
+
+    await expect(Context.deleteSession(sessionId)).resolves.toEqual(true);
+    expect(delete_called).toBe(true);
+  });
 });

--- a/src/test/test_helper.ts
+++ b/src/test/test_helper.ts
@@ -1,4 +1,5 @@
 import { Context } from '../context';
+import { ApiVersion } from '../types';
 import fetchMock from  'jest-fetch-mock';
 
 fetchMock.enableMocks();
@@ -10,6 +11,7 @@ beforeEach(() => {
     API_SECRET_KEY: 'test_secret_key',
     SCOPES: ['test_scope'],
     HOST_NAME: 'test_host_name',
+    API_VERSION: ApiVersion.Unstable,
   });
 
   fetchMock.resetMocks();

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface ContextParams {
   API_SECRET_KEY: string,
   SCOPES: string[],
   HOST_NAME: string,
+  API_VERSION: ApiVersion,
   SESSION_STORAGE?: SessionStorage,
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Every REST request to the Admin API will need to include the API version in the path. To make sure we're using a consistent version throughout the app, we can now initialize the API version when the app starts (and override at any point later on) in Context.

### WHAT is this pull request doing?

Add the API version to Context, and append that to the path for REST requests.

## Type of change

- [X] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have added/updated tests for this change