### PR TITLE
Replace axios with node-fetch to make HTTP requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "license": "MIT",
   "dependencies": {
     "@shopify/network": "^1.5.1",
-    "axios": "^0.21.0",
+    "@types/node-fetch": "^2.5.7",
+    "node-fetch": "^2.6.1",
     "tslib": "^2.0.3"
   },
   "devDependencies": {
@@ -32,6 +33,7 @@
     "eslint-plugin-shopify": "^35.1.0",
     "eslint-plugin-tsdoc": "^0.2.7",
     "jest": "^26.4.2",
+    "jest-fetch-mock": "^3.0.3",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.1",
     "typedoc": "^0.19.2",

--- a/src/clients/rest/test/rest_client.test.ts
+++ b/src/clients/rest/test/rest_client.test.ts
@@ -1,9 +1,9 @@
 import '../../../test/test_helper';
 import { ShopifyHeader } from '../../../types';
-import { axiosMock, buildHttpResponse, assertHttpRequest } from '../../test/test_helper';
+import { assertHttpRequest } from '../../test/test_helper';
 import { RestClient } from '../rest_client';
 
-const domain = 'test-shop.myshopify.com';
+const domain = 'test-shop'; // Omitting the myshopify.com part to fail if real requests are made
 const successResponse = {
   products: [
     {
@@ -14,12 +14,10 @@ const successResponse = {
 };
 
 describe("REST client", () => {
-  beforeEach(axiosMock.request.mockRestore);
-
   it("can make GET request", async () => {
     const client = new RestClient(domain, 'dummy-token');
 
-    axiosMock.request.mockReturnValue(buildHttpResponse(successResponse));
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
     await expect(client.get('products')).resolves.toEqual(successResponse);
     assertHttpRequest('GET', domain, '/admin/products.json');
@@ -28,7 +26,7 @@ describe("REST client", () => {
   it("can make POST request", async () => {
     const client = new RestClient(domain, 'dummy-token');
 
-    axiosMock.request.mockReturnValue(buildHttpResponse(successResponse));
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
     const postData = {
       title: 'Test product',
@@ -42,7 +40,7 @@ describe("REST client", () => {
   it("can make PUT request", async () => {
     const client = new RestClient(domain, 'dummy-token');
 
-    axiosMock.request.mockReturnValue(buildHttpResponse(successResponse));
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
     const postData = {
       title: 'Test product',
@@ -56,7 +54,7 @@ describe("REST client", () => {
   it("can make DELETE request", async () => {
     const client = new RestClient(domain, 'dummy-token');
 
-    axiosMock.request.mockReturnValue(buildHttpResponse(successResponse));
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
     await expect(client.delete('products/123')).resolves.toEqual(successResponse);
     assertHttpRequest('DELETE', domain, '/admin/products/123.json');
@@ -69,7 +67,7 @@ describe("REST client", () => {
       'X-Not-A-Real-Header': 'some_value',
     };
 
-    axiosMock.request.mockReturnValue(buildHttpResponse(successResponse));
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
     await expect(client.get('products', customHeaders)).resolves.toEqual(successResponse);
 

--- a/src/clients/test/http_client.test.ts
+++ b/src/clients/test/http_client.test.ts
@@ -1,20 +1,17 @@
 import '../../test/test_helper';
-import { axiosMock, buildHttpResponse, assertHttpRequest } from './test_helper';
+import { assertHttpRequest } from './test_helper';
 
 import { HttpClient } from '../http_client';
 import ShopifyErrors from '../../error';
-import { AxiosError, AxiosResponse } from 'axios';
 
-const domain = 'test-shop.myshopify.com';
+const domain = 'test-shop'; // Omitting the myshopify.com part to fail if real requests are made
 const successResponse = { message: "Your HTTP request was successful!" };
 
 describe("HTTP client", () => {
-  beforeEach(axiosMock.request.mockRestore);
-
   test("can make GET request", async () => {
     const client = new HttpClient(domain);
 
-    axiosMock.request.mockReturnValue(buildHttpResponse(successResponse));
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
     await expect(client.get('/url/path')).resolves.toEqual(successResponse);
     assertHttpRequest('GET', domain, '/url/path');
@@ -23,7 +20,7 @@ describe("HTTP client", () => {
   test("can make POST request", async () => {
     const client = new HttpClient(domain);
 
-    axiosMock.request.mockReturnValue(buildHttpResponse(successResponse));
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
     const postData = {
       title: 'Test product',
@@ -37,7 +34,7 @@ describe("HTTP client", () => {
   test("can make PUT request", async () => {
     const client = new HttpClient(domain);
 
-    axiosMock.request.mockReturnValue(buildHttpResponse(successResponse));
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
     const postData = {
       title: 'Test product',
@@ -51,7 +48,7 @@ describe("HTTP client", () => {
   test("can make DELETE request", async () => {
     const client = new HttpClient(domain);
 
-    axiosMock.request.mockReturnValue(buildHttpResponse(successResponse));
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
     await expect(client.delete('/url/path/123')).resolves.toEqual(successResponse);
     assertHttpRequest('DELETE', domain, '/url/path/123');
@@ -61,17 +58,23 @@ describe("HTTP client", () => {
     const client = new HttpClient(domain);
 
     const testErrorResponse = async (status: number | null, expectedError: NewableFunction) => {
-      const errorResponse: AxiosError = {
-        message: "Something went wrong!",
-      } as AxiosError;
-      if (status) {
-        errorResponse.response = {
-          status: status,
-        } as AxiosResponse;
-      }
+      const errorResponse = {
+        errors: 'Something went wrong!',
+      };
 
-      axiosMock.request.mockRestore();
-      axiosMock.request.mockRejectedValue(errorResponse);
+      fetchMock.resetMocks();
+      if (status !== null) {
+        const headers = new Headers();
+        headers.append('content-type', 'application/json; charset=utf-8');
+        const responseObject = new Response(JSON.stringify(errorResponse), {
+          status: status,
+          headers,
+        });
+        fetchMock.mockImplementation(() => Promise.resolve(responseObject));
+      }
+      else {
+        fetchMock.mockRejectOnce(() => Promise.reject());
+      }
 
       const expectResult = expect(client.get('/url/path')).rejects;
       await expectResult.toBeInstanceOf(expectedError);
@@ -96,7 +99,7 @@ describe("HTTP client", () => {
       'X-Not-A-Real-Header': 'some_value',
     };
 
-    axiosMock.request.mockReturnValue(buildHttpResponse(successResponse));
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
     await expect(client.get('/url/path', customHeaders)).resolves.toEqual(successResponse);
     assertHttpRequest('GET', domain, '/url/path', customHeaders);

--- a/src/clients/test/test_helper.ts
+++ b/src/clients/test/test_helper.ts
@@ -1,28 +1,19 @@
 import querystring, { ParsedUrlQueryInput } from 'querystring';
-
-import axios from 'axios';
-jest.mock('axios');
-export const axiosMock = axios as jest.Mocked<typeof axios>;
-
-export function buildHttpResponse(data: unknown): Promise<unknown> {
-  return Promise.resolve({
-    status: 200,
-    data: data,
-  });
-}
+import fetchMock from  'jest-fetch-mock';
 
 export function assertHttpRequest(
   method: string,
   domain: string,
-  url: string,
+  path: string,
   headers: Record<string, unknown> = {},
   data: ParsedUrlQueryInput | null = null
 ): void {
-  expect(axiosMock.request).toBeCalledWith(expect.objectContaining({
-    method: method,
-    baseURL: `https://${domain}`,
-    url: url,
-    headers: expect.objectContaining(headers),
-    data: data ? querystring.stringify(data) : null,
-  }));
+  expect(fetchMock).toBeCalledWith(
+    `https://${domain}${path}`,
+    expect.objectContaining({
+      method: method,
+      headers: expect.objectContaining(headers),
+      body: data ? querystring.stringify(data) : null,
+    })
+  );
 }

--- a/src/test/test_helper.ts
+++ b/src/test/test_helper.ts
@@ -1,4 +1,7 @@
-import { Context } from "../context"
+import { Context } from '../context';
+import fetchMock from  'jest-fetch-mock';
+
+fetchMock.enableMocks();
 
 beforeEach(() => {
   // We want to reset the Context object on every run so that tests start with a consistent state
@@ -8,4 +11,6 @@ beforeEach(() => {
     SCOPES: ['test_scope'],
     HOST_NAME: 'test_host_name',
   });
+
+  fetchMock.resetMocks();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -685,6 +685,14 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
+"@types/node-fetch@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
+  integrity sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "14.10.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.10.1.tgz#cc323bad8e8a533d4822f45ce4e5326f36e42177"
@@ -1040,13 +1048,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
-axios@^0.21.0:
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.0.tgz#26df088803a2350dff2c27f96fef99fe49442aca"
-  integrity sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==
-  dependencies:
-    follow-redirects "^1.10.0"
-
 axobject-query@^2.0.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -1369,7 +1370,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -1434,6 +1435,13 @@ cross-fetch@2.2.2:
   dependencies:
     node-fetch "2.1.2"
     whatwg-fetch "2.0.4"
+
+cross-fetch@^3.0.4:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
+  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
+  dependencies:
+    node-fetch "2.6.1"
 
 cross-spawn@^6.0.0:
   version "6.0.5"
@@ -2300,11 +2308,6 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-follow-redirects@^1.10.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
-  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
-
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -2314,6 +2317,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
+  integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -3063,6 +3075,14 @@ jest-environment-node@^26.3.0:
     jest-mock "^26.3.0"
     jest-util "^26.3.0"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
@@ -3755,6 +3775,11 @@ node-fetch@2.1.2:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
+node-fetch@2.6.1, node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -4173,6 +4198,11 @@ progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+promise-polyfill@^8.1.3:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.0.tgz#367394726da7561457aba2133c9ceefbd6267da0"
+  integrity sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==
 
 prompts@^2.0.1:
   version "2.3.2"


### PR DESCRIPTION
### WHY are these changes introduced?

The HTTP client was originally using axios, which is too feature-rich for our simple needs, as it also supports browser requests. We decided to go with `node-fetch` instead which is meant for the backend and is more streamlined.

### WHAT is this pull request doing?

Replaced the packages and adapted the HTTP client calls accordingly.

## Type of change

- [X] Minor: New feature (non-breaking change which adds functionality)


## Checklist

- [X] I have added/updated tests for this change
