### PR TITLE
Adds base OAuth functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,16 @@
   "dependencies": {
     "@shopify/network": "^1.5.1",
     "@types/node-fetch": "^2.5.7",
+    "cookies": "^0.8.0",
     "node-fetch": "^2.6.1",
-    "tslib": "^2.0.3"
+    "tslib": "^2.0.3",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
+    "@types/cookies": "^0.7.5",
+    "@types/jest": "^26.0.15",
+    "@types/node": "^14.14.1",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.6.0",
     "@typescript-eslint/parser": "^4.6.0",
     "eslint": "^7.9.0",

--- a/src/auth/oauth/index.ts
+++ b/src/auth/oauth/index.ts
@@ -1,0 +1,3 @@
+import { ShopifyOAuth } from './oauth';
+
+export { ShopifyOAuth };

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -1,0 +1,135 @@
+import { v4 as uuidv4 } from 'uuid';
+import http from 'http';
+import Cookies from 'cookies';
+import { Context } from '../../context';
+import utils from '../../utils';
+import querystring from 'querystring';
+import { AuthQuery, AccessTokenResponse, OnlineAccessResponse } from '../types';
+import { Session } from '../session';
+import { DataType, HttpClient } from '../../clients/http_client';
+import ShopifyErrors from '../../error';
+
+const ShopifyOAuth = {
+  async beginAuth(
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+    shop: string,
+    redirect: string,
+    isOnline = false
+  ): Promise<string> {
+    Context.throwIfUnitialized();
+
+    const cookies = new Cookies(request, response, {
+      keys: [Context.API_SECRET_KEY],
+    });
+
+    const state = utils.nonce();
+
+    const session = new Session(isOnline ? uuidv4() : shop + '_offline');
+    session.shop = shop;
+    session.state = state;
+    session.isOnline = isOnline;
+
+    await Context.storeSession(session);
+
+    cookies.set('shopify_app_session', session.id, {
+      signed: true,
+      expires: new Date(Date.now() + 60000),
+    });
+
+    const query = {
+      client_id: Context.API_KEY,
+      scope: Context.SCOPES,
+      redirect_uri: redirect,
+      state: state,
+      'grant_options[]': isOnline ? 'per_user' : '',
+    };
+
+    const queryString = querystring.stringify(query);
+
+    return `https://${shop}/admin/oauth/authorize?${queryString}`;
+  },
+
+  async validateAuthCallback(
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+    query: AuthQuery
+  ): Promise<void> {
+    Context.throwIfUnitialized();
+
+    const cookies = new Cookies(request, response, {
+      keys: [Context.API_SECRET_KEY],
+    });
+
+    const sessionCookie: string | undefined = cookies.get(
+      'shopify_app_session',
+      { signed: true }
+    );
+
+    if (!sessionCookie) {
+      throw new ShopifyErrors.SessionNotFound(
+        `Cannot complete OAuth process. No session cookie found for the specified shop url: ${query.shop}`
+      );
+    }
+
+    const currentSession = await Context.loadSession(sessionCookie);
+
+    if (!currentSession) {
+      throw new ShopifyErrors.SessionNotFound(
+        `Cannot complete OAuth process. No session found for the specified shop url: ${query.shop}`
+      );
+    }
+
+    if (!validQuery(query, currentSession)) {
+      throw new ShopifyErrors.InvalidOAuthError('Invalid OAuth callback.');
+    }
+
+    const body = {
+      client_id: Context.API_KEY,
+      client_secret: Context.API_SECRET_KEY,
+      code: query.code,
+    };
+
+    const postParams = {
+      path: '/admin/oauth/access_token',
+      type: DataType.JSON,
+      data: body,
+    };
+
+    const client = new HttpClient(currentSession.shop);
+    if (currentSession.isOnline) {
+      const response = (await client.post(postParams)) as OnlineAccessResponse;
+
+      const { access_token, scope, ...rest } = response;
+      const sessionExpiration = new Date(
+        Date.now() + response.expires_in * 1000
+      );
+      currentSession.accessToken = access_token;
+      currentSession.expires = sessionExpiration;
+      currentSession.scope = scope;
+      currentSession.onlineAccesInfo = rest;
+
+      cookies.set('shopify_app_session', sessionCookie, {
+        signed: true,
+        domain: Context.HOST_NAME,
+        expires: sessionExpiration,
+      });
+    } else {
+      const response = (await client.post(postParams)) as AccessTokenResponse;
+      currentSession.accessToken = response.access_token;
+      currentSession.scope = response.scope;
+    }
+
+    await Context.storeSession(currentSession);
+  },
+};
+
+function validQuery(query: AuthQuery, session: Session): boolean {
+  return (
+    utils.validateHmac(query) &&
+    utils.validateShop(query.shop) &&
+    utils.safeCompare(query.state, session.state as string)
+  );
+}
+
+export { ShopifyOAuth };

--- a/src/auth/oauth/test/oauth.test.ts
+++ b/src/auth/oauth/test/oauth.test.ts
@@ -1,0 +1,303 @@
+import '../../../test/test_helper';
+import { ShopifyOAuth } from '../oauth';
+import { Context } from '../../../context';
+import ShopifyErrors from '../../../error';
+import { generateLocalHmac } from '../../../utils/hmac-validator';
+import { AuthQuery } from '../../types';
+import querystring from 'querystring';
+import http from 'http';
+
+jest.mock('cookies');
+import Cookies from 'cookies';
+
+let shop: string;
+
+beforeEach(() => {
+  shop = 'someshop.myshopify.io';
+  (Cookies as any).mockClear(); // eslint-disable-line @typescript-eslint/no-explicit-any
+});
+
+describe('beginAuth', () => {
+  let cookies = {
+    id: '',
+  };
+  let req: http.IncomingMessage;
+  let res: http.ServerResponse;
+
+  beforeEach(() => {
+    cookies = {
+      id: '',
+    };
+
+    req = {} as http.IncomingMessage;
+    res = {} as http.ServerResponse;
+
+    Cookies.prototype.set.mockImplementation(
+      (cookieName: string, cookieValue: string) => {
+        expect(cookieName).toBe('shopify_app_session');
+        cookies.id = cookieValue;
+      }
+    );
+  });
+
+  test('throws Context error when not properly initialized', async () => {
+    Context.API_KEY = '';
+
+    await expect(() =>
+      ShopifyOAuth.beginAuth(
+        req,
+        res,
+        shop,
+        Context.HOST_NAME + '/some-callback'
+      )
+    ).rejects.toBeInstanceOf(ShopifyErrors.UninitializedContextError);
+  });
+
+  test('creates and stores a new session for the specified shop', async () => {
+    const authRoute = await ShopifyOAuth.beginAuth(
+      req,
+      res,
+      shop,
+      Context.HOST_NAME + '/some-callback'
+    );
+    const session = await Context.loadSession(cookies.id);
+
+    expect(Cookies).toHaveBeenCalledTimes(1);
+    expect(Cookies.prototype.set).toHaveBeenCalledTimes(1);
+    expect(authRoute).toBeDefined();
+    expect(session).toBeDefined();
+    expect(session).toHaveProperty('id');
+    expect(session).toHaveProperty('shop', shop);
+    expect(session).toHaveProperty('state');
+    expect(session).toHaveProperty('expires', undefined);
+  });
+
+  test('sets session id and cookie to shop name with "_offline" for offline access requests', async () => {
+    await ShopifyOAuth.beginAuth(
+      req,
+      res,
+      shop,
+      Context.HOST_NAME + '/some-callback'
+    );
+
+    expect(cookies.id).toBe(shop + '_offline');
+  });
+
+  test('returns the correct auth url for given info', async () => {
+    const authRoute = await ShopifyOAuth.beginAuth(
+      req,
+      res,
+      shop,
+      Context.HOST_NAME + '/some-callback'
+    );
+    const session = await Context.loadSession(cookies.id);
+    const query = {
+      client_id: Context.API_KEY,
+      scope: Context.SCOPES,
+      redirect_uri: Context.HOST_NAME + '/some-callback',
+      state: session ? session.state : '',
+      'grant_options[]': '',
+    };
+
+    const expectedQueryString = querystring.stringify(query);
+
+    expect(authRoute).toBe(
+      `https://${shop}/admin/oauth/authorize?${expectedQueryString}`
+    );
+  });
+
+  test('appends per_user access mode to url when isOnline is set to true', async () => {
+    const authRoute = await ShopifyOAuth.beginAuth(
+      req,
+      res,
+      shop,
+      Context.HOST_NAME + '/some-callback',
+      true
+    );
+    const session = await Context.loadSession(cookies.id);
+
+    const query = {
+      client_id: Context.API_KEY,
+      scope: Context.SCOPES,
+      redirect_uri: Context.HOST_NAME + '/some-callback',
+      state: session ? session.state : '',
+      'grant_options[]': 'per_user',
+    };
+    const expectedQueryString = querystring.stringify(query);
+
+    expect(authRoute).toBe(
+      `https://${shop}/admin/oauth/authorize?${expectedQueryString}`
+    );
+  });
+});
+
+describe('validateAuthCallback', () => {
+  let cookies = {
+    id: '',
+  };
+  let req: http.IncomingMessage;
+  let res: http.ServerResponse;
+
+  beforeEach(() => {
+    cookies = {
+      id: '',
+    };
+
+    req = {} as http.IncomingMessage;
+    res = {} as http.ServerResponse;
+
+    Cookies.prototype.set.mockImplementation(
+      (cookieName: string, cookieValue: string) => {
+        expect(cookieName).toBe('shopify_app_session');
+        cookies.id = cookieValue;
+      }
+    );
+
+    Cookies.prototype.get.mockImplementation(() => cookies.id);
+  });
+
+  test('throws Context error when not properly initialized', async () => {
+    Context.API_KEY = '';
+    const session = await Context.loadSession(cookies.id);
+    const testCallbackQuery: AuthQuery = {
+      shop: shop,
+      state: session ? session.state : '',
+      timestamp: (+new Date()).toString(),
+      code: 'some random auth code',
+    };
+    const expectedHmac = generateLocalHmac(testCallbackQuery);
+    testCallbackQuery.hmac = expectedHmac;
+
+    await expect(() =>
+      ShopifyOAuth.validateAuthCallback(req, res, testCallbackQuery)
+    ).rejects.toBeInstanceOf(ShopifyErrors.UninitializedContextError);
+  });
+
+  test("throws an error when receiving a callback for a shop that doesn't have a session cookie", async () => {
+    await expect(() =>
+      ShopifyOAuth.validateAuthCallback(req, res, {
+        shop: 'I do not exist',
+      } as AuthQuery)
+    ).rejects.toBeInstanceOf(ShopifyErrors.SessionNotFound);
+  });
+
+  test('throws an error when receiving a callback for a shop with no saved session', async () => {
+    await ShopifyOAuth.beginAuth(
+      req,
+      res,
+      'invalidurl.com',
+      Context.HOST_NAME + '/some-callback'
+    );
+
+    Context.deleteSession(cookies.id);
+
+    await expect(() =>
+      ShopifyOAuth.validateAuthCallback(req, res, {
+        shop: 'I do not exist',
+      } as AuthQuery)
+    ).rejects.toBeInstanceOf(ShopifyErrors.SessionNotFound);
+  });
+
+  test('throws error when callback includes invalid hmac, or state', async () => {
+    await ShopifyOAuth.beginAuth(
+      req,
+      res,
+      'invalidurl.com',
+      Context.HOST_NAME + '/some-callback'
+    );
+    const testCallbackQuery: AuthQuery = {
+      shop: 'invalidurl.com',
+      state: 'incorrect',
+      timestamp: (+new Date()).toString(),
+      code: 'some random auth code',
+    };
+    testCallbackQuery.hmac = 'definitely the wrong hmac';
+
+    await expect(() =>
+      ShopifyOAuth.validateAuthCallback(req, res, testCallbackQuery)
+    ).rejects.toBeInstanceOf(ShopifyErrors.InvalidOAuthError);
+  });
+
+  test('requests access token for valid callbacks with offline access and updates session', async () => {
+    await ShopifyOAuth.beginAuth(
+      req,
+      res,
+      shop,
+      Context.HOST_NAME + '/some-callback'
+    );
+    let session = await Context.loadSession(cookies.id);
+    const testCallbackQuery: AuthQuery = {
+      shop: shop,
+      state: session ? session.state : '',
+      timestamp: (+new Date()).toString(),
+      code: 'some random auth code',
+    };
+    const expectedHmac = generateLocalHmac(testCallbackQuery);
+    testCallbackQuery.hmac = expectedHmac;
+
+    const successResponse = {
+      access_token: 'some access token string',
+      scope: Context.SCOPES.join(','),
+    };
+
+    fetchMock.mockResponse(JSON.stringify(successResponse));
+    await ShopifyOAuth.validateAuthCallback(req, res, testCallbackQuery);
+    session = await Context.loadSession(cookies.id);
+
+    session
+      ? expect(session.accessToken).toBe(successResponse.access_token)
+      : false;
+  });
+
+  test('requests access token for valid callbacks with online access and updates session with expiration and onlineAccessInfo', async () => {
+    await ShopifyOAuth.beginAuth(
+      req,
+      res,
+      shop,
+      Context.HOST_NAME + '/some-callback',
+      true
+    );
+    const session = await Context.loadSession(cookies.id);
+    const testCallbackQuery: AuthQuery = {
+      shop: shop,
+      state: session ? session.state : '',
+      timestamp: (+new Date()).toString(),
+      code: 'some random auth code',
+    };
+    const expectedHmac = generateLocalHmac(testCallbackQuery);
+    testCallbackQuery.hmac = expectedHmac;
+
+    const successResponse = {
+      access_token: 'some access token',
+      scope: 'pet_kitties, walk_dogs',
+      expires_in: '525600',
+      associated_user_scope: 'pet_kitties',
+      associated_user: {
+        id: '8675309',
+        first_name: 'Tobi',
+        last_name: 'Lutke',
+        email: 'tobi@shopify.com',
+        email_verified: true,
+        account_owner: true,
+        locale: 'en',
+        collaborator: true,
+      },
+    };
+
+    const expectedOnlineAccessInfo = {
+      expires_in: successResponse.expires_in,
+      associated_user_scope: successResponse.associated_user_scope,
+      associated_user: successResponse.associated_user,
+    };
+
+    fetchMock.mockResponse(JSON.stringify(successResponse));
+    await ShopifyOAuth.validateAuthCallback(req, res, testCallbackQuery);
+    if (session) {
+      expect(session.accessToken).toBe(successResponse.access_token);
+      expect(session.expires).toBeInstanceOf(Date);
+      expect(session.onlineAccesInfo).toEqual(expectedOnlineAccessInfo);
+    } else {
+      return false;
+    }
+  });
+});

--- a/src/auth/session/session.ts
+++ b/src/auth/session/session.ts
@@ -1,16 +1,17 @@
+import { OnlineAccessInfo } from '../types';
 /**
  * Stores App information from logged in merchants so they can make authenticated requests to the Admin API.
  */
 class Session {
-  /** Unique id by which to store / load the session */
-  readonly id: string;
-  /** When the session expires, in ms from epoch */
-  public expires: number;
+  public shop: string;
+  public state: string;
+  public scope: string;
+  public expires?: Date;
+  public isOnline?: boolean;
+  public accessToken?: string;
+  public onlineAccesInfo?: OnlineAccessInfo;
 
-  constructor(id: string, expires: number) {
-    this.id = id;
-    this.expires = expires;
-  }
+  constructor(readonly id: string) {}
 }
 
 export { Session };

--- a/src/auth/session/test/custom.test.ts
+++ b/src/auth/session/test/custom.test.ts
@@ -3,9 +3,9 @@ import '../../../test/test_helper';
 import { Session } from '../session';
 import { CustomSessionStorage } from '../storage/custom';
 
-test("can use custom session storage", async () => {
+test('can use custom session storage', async () => {
   const sessionId = 'test_session';
-  const session = new Session(sessionId, (new Date()).getTime() + 86400000);
+  const session = new Session(sessionId);
 
   let store_called = false;
   let load_called = false;
@@ -22,7 +22,7 @@ test("can use custom session storage", async () => {
     () => {
       delete_called = true;
       return true;
-    },
+    }
   );
 
   await expect(storage.storeSession(session)).resolves.toBe(true);
@@ -49,14 +49,14 @@ test("can use custom session storage", async () => {
   expect(delete_called).toBe(true);
 });
 
-test("custom session storage failures and exceptions are raised", async () => {
+test('custom session storage failures and exceptions are raised', async () => {
   const sessionId = 'test_session';
-  const session = new Session(sessionId, (new Date()).getTime() + 86400000);
+  const session = new Session(sessionId);
 
   let storage = new CustomSessionStorage(
     () => false,
     () => null,
-    () => false,
+    () => false
   );
 
   await expect(storage.storeSession(session)).resolves.toBe(false);
@@ -64,12 +64,24 @@ test("custom session storage failures and exceptions are raised", async () => {
   await expect(storage.deleteSession(sessionId)).resolves.toBe(false);
 
   storage = new CustomSessionStorage(
-    () => { throw 'Failed to store!'; },
-    () => { throw 'Failed to load!'; },
-    () => { throw 'Failed to delete!'; },
+    () => {
+      throw 'Failed to store!';
+    },
+    () => {
+      throw 'Failed to load!';
+    },
+    () => {
+      throw 'Failed to delete!';
+    }
   );
 
-  await expect(storage.storeSession(session)).rejects.toEqual('Failed to store!');
-  await expect(storage.loadSession(sessionId)).rejects.toEqual('Failed to load!');
-  await expect(storage.deleteSession(sessionId)).rejects.toEqual('Failed to delete!');
+  await expect(storage.storeSession(session)).rejects.toEqual(
+    'Failed to store!'
+  );
+  await expect(storage.loadSession(sessionId)).rejects.toEqual(
+    'Failed to load!'
+  );
+  await expect(storage.deleteSession(sessionId)).rejects.toEqual(
+    'Failed to delete!'
+  );
 });

--- a/src/auth/session/test/memory.test.ts
+++ b/src/auth/session/test/memory.test.ts
@@ -3,10 +3,10 @@ import '../../../test/test_helper';
 import { Session } from '../session';
 import { MemorySessionStorage } from '../storage/memory';
 
-test("can store and delete sessions in memory", async () => {
+test('can store and delete sessions in memory', async () => {
   const sessionId = 'test_session';
   const storage = new MemorySessionStorage();
-  const session = new Session(sessionId, (new Date()).getTime() + 86400000);
+  const session = new Session(sessionId);
 
   await expect(storage.storeSession(session)).resolves.toBe(true);
   await expect(storage.loadSession(sessionId)).resolves.toEqual(session);
@@ -21,7 +21,7 @@ test("can store and delete sessions in memory", async () => {
   await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
 });
 
-test("wrong ids return null sessions from memory", async () => {
+test('wrong ids return null sessions from memory', async () => {
   const storage = new MemorySessionStorage();
   await expect(storage.loadSession('not_a_session_id')).resolves.toBeNull();
 });

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -1,7 +1,31 @@
-export interface AuthQueryObject {
-  code: string,
-  timestamp: string,
-  state: string,
-  shop: string,
-  hmac?: string
+export interface AuthQuery {
+  code: string;
+  timestamp: string;
+  state: string;
+  shop: string;
+  hmac?: string;
 }
+
+export interface AccessTokenResponse {
+  access_token: string;
+  scope: string;
+}
+
+export interface OnlineAccessInfo {
+  expires_in: number;
+  associated_user_scope: string;
+  associated_user: {
+    id: number;
+    first_name: string;
+    last_name: string;
+    email: string;
+    email_verified: boolean;
+    account_owner: boolean;
+    locale: string;
+    collaborator: boolean;
+  };
+}
+
+export interface OnlineAccessResponse
+  extends AccessTokenResponse,
+    OnlineAccessInfo {}

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,35 +3,41 @@ import { Session, SessionStorage, MemorySessionStorage } from './auth/session';
 import { ApiVersion, ContextParams } from './types';
 
 interface ContextInterface extends ContextParams {
-  SESSION_STORAGE: SessionStorage,
+  SESSION_STORAGE: SessionStorage;
 
   /**
    * Sets up the Shopify App Dev Kit to be able to integrate with Shopify and run authenticated commands.
    *
    * @param params Settings to update
    */
-  initialize(params: ContextParams): void,
+  initialize(params: ContextParams): void;
 
   /**
    * Creates or updates the given session using the assigned strategy.
    *
    * @param session Session to store
    */
-  storeSession(session: Session): Promise<boolean>,
+  storeSession(session: Session): Promise<boolean>;
 
   /**
    * Loads a session using the assigned strategy.
    *
    * @param id Id of the session to load
    */
-  loadSession(id: string): Promise<Session | null>,
+  loadSession(id: string): Promise<Session | null>;
 
   /**
    * Deletes a session using the assigned strategy.
    *
    * @param id Id of the session to delete
    */
-  deleteSession(id: string): Promise<boolean>,
+  deleteSession(id: string): Promise<boolean>;
+
+  /**
+   * Throws error if context has not been initialized.
+   */
+
+  throwIfUnitialized(): void | never;
 }
 
 const Context: ContextInterface = {
@@ -85,6 +91,14 @@ const Context: ContextInterface = {
 
   async deleteSession(id: string): Promise<boolean> {
     return this.SESSION_STORAGE.deleteSession(id);
+  },
+
+  throwIfUnitialized(): void {
+    if (!this.API_KEY || this.API_KEY.length == 0) {
+      throw new ShopifyErrors.UninitializedContextError(
+        'Context has not been properly initialized. Please call the .initialize() method to setup your app context object.'
+      );
+    }
   },
 };
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -4,17 +4,29 @@ class InvalidHmacError extends ShopifyError {}
 class InvalidShopError extends ShopifyError {}
 
 class SafeCompareError extends ShopifyError {}
+class UninitializedContextError extends ShopifyError {}
 
 class HttpRequestError extends ShopifyError {}
 class HttpMaxRetriesError extends ShopifyError {}
 class HttpResponseError extends ShopifyError {
-  public constructor(message: string, readonly code: number, readonly statusText: string) { super(message); }
+  public constructor(
+    message: string,
+    readonly code: number,
+    readonly statusText: string
+  ) {
+    super(message);
+  }
 }
 class HttpRetriableError extends ShopifyError {}
 class HttpInternalError extends HttpRetriableError {}
 class HttpThrottlingError extends HttpRetriableError {
-  public constructor(message: string, readonly retryAfter?: number) { super(message); }
+  public constructor(message: string, readonly retryAfter?: number) {
+    super(message);
+  }
 }
+
+class InvalidOAuthError extends ShopifyError {}
+class SessionNotFound extends ShopifyError {}
 
 const ShopifyErrors = {
   ShopifyError,
@@ -27,6 +39,9 @@ const ShopifyErrors = {
   HttpRetriableError,
   HttpInternalError,
   HttpThrottlingError,
+  UninitializedContextError,
+  InvalidOAuthError,
+  SessionNotFound,
 };
 
 export default ShopifyErrors;

--- a/src/test/context.test.ts
+++ b/src/test/context.test.ts
@@ -15,12 +15,12 @@ const validParams: ContextParams = {
 
 const originalWarn = console.warn;
 
-describe("Context object", () => {
+describe('Context object', () => {
   afterEach(() => {
     console.warn = originalWarn;
   });
 
-  it("can initialize and update context", () => {
+  it('can initialize and update context', () => {
     Context.initialize(validParams);
 
     expect(Context.API_KEY).toEqual(validParams.API_KEY);
@@ -35,8 +35,7 @@ describe("Context object", () => {
     try {
       Context.initialize(invalid);
       fail('Initializing without API_KEY did not throw an exception');
-    }
-    catch (e) {
+    } catch (e) {
       expect(e).toBeInstanceOf(ShopifyErrors.ShopifyError);
       expect(e.message).toContain('Missing values for: API_KEY');
     }
@@ -46,8 +45,7 @@ describe("Context object", () => {
     try {
       Context.initialize(invalid);
       fail('Initializing without API_SECRET_KEY did not throw an exception');
-    }
-    catch (e) {
+    } catch (e) {
       expect(e).toBeInstanceOf(ShopifyErrors.ShopifyError);
       expect(e.message).toContain('Missing values for: API_SECRET_KEY');
     }
@@ -57,8 +55,7 @@ describe("Context object", () => {
     try {
       Context.initialize(invalid);
       fail('Initializing without SCOPES did not throw an exception');
-    }
-    catch (e) {
+    } catch (e) {
       expect(e).toBeInstanceOf(ShopifyErrors.ShopifyError);
       expect(e.message).toContain('Missing values for: SCOPES');
     }
@@ -68,8 +65,7 @@ describe("Context object", () => {
     try {
       Context.initialize(invalid);
       fail('Initializing without HOST_NAME did not throw an exception');
-    }
-    catch (e) {
+    } catch (e) {
       expect(e).toBeInstanceOf(ShopifyErrors.ShopifyError);
       expect(e.message).toContain('Missing values for: HOST_NAME');
     }
@@ -84,20 +80,20 @@ describe("Context object", () => {
     expect(() => Context.initialize(empty)).toThrow(ShopifyErrors.ShopifyError);
   });
 
-  it("can store, load and delete memory sessions by default", async () => {
+  it('can store, load and delete memory sessions by default', async () => {
     Context.initialize(validParams);
 
     const sessionId = 'test_session';
-    const session = new Session(sessionId, (new Date()).getTime() + 86400000);
+    const session = new Session(sessionId);
 
     await expect(Context.storeSession(session)).resolves.toEqual(true);
     await expect(Context.loadSession(sessionId)).resolves.toEqual(session);
     await expect(Context.deleteSession(sessionId)).resolves.toEqual(true);
   });
 
-  it("can store, load and delete custom storage sessions", async () => {
+  it('can store, load and delete custom storage sessions', async () => {
     const sessionId = 'test_session';
-    const session = new Session(sessionId, (new Date()).getTime() + 86400000);
+    const session = new Session(sessionId);
 
     let store_called = false;
     let load_called = false;
@@ -114,19 +110,17 @@ describe("Context object", () => {
       () => {
         delete_called = true;
         return true;
-      },
+      }
     );
 
-    Context.initialize(
-      {
-        API_KEY: 'api_key',
-        API_SECRET_KEY: 'api_secret_key',
-        SCOPES: ['do_one_thing', 'do_something_else'],
-        HOST_NAME: 'host_name',
-        API_VERSION: ApiVersion.Unstable,
-        SESSION_STORAGE: storage,
-      },
-    );
+    Context.initialize({
+      API_KEY: 'api_key',
+      API_SECRET_KEY: 'api_secret_key',
+      SCOPES: ['do_one_thing', 'do_something_else'],
+      HOST_NAME: 'host_name',
+      API_VERSION: ApiVersion.Unstable,
+      SESSION_STORAGE: storage,
+    });
 
     await expect(Context.storeSession(session)).resolves.toEqual(true);
     expect(store_called).toBe(true);

--- a/src/utils/hmac-validator.ts
+++ b/src/utils/hmac-validator.ts
@@ -1,24 +1,21 @@
 import crypto from 'crypto';
 import querystring from 'querystring';
-import { AuthQueryObject } from '../auth/types';
+import { AuthQuery } from '../auth/types';
 import safeCompare from './safe-compare';
 import ShopifyErrors from '../error';
 import { Context } from '../context';
 
-function stringifyQuery(query: AuthQueryObject): string {
+export function stringifyQuery(query: AuthQuery): string {
   const orderedObj = Object.keys(query)
     .sort((val1, val2) => val1.localeCompare(val2))
-    .reduce((
-      a: { [key: string]: string | undefined },
-      k: keyof AuthQueryObject
-    ) => {
+    .reduce((a: { [key: string]: string | undefined }, k: keyof AuthQuery) => {
       a[k] = query[k];
       return a;
     }, {});
   return querystring.stringify(orderedObj);
 }
 
-function generateLocalHmac(query: AuthQueryObject): string {
+export function generateLocalHmac(query: AuthQuery): string {
   const queryString = stringifyQuery(query);
   return crypto
     .createHmac('sha256', Context.API_SECRET_KEY)
@@ -26,9 +23,11 @@ function generateLocalHmac(query: AuthQueryObject): string {
     .digest('hex');
 }
 
-export default function validateHmac(query: AuthQueryObject): boolean {
+export default function validateHmac(query: AuthQuery): boolean {
   if (!query.hmac) {
-    throw new ShopifyErrors.InvalidHmacError('Query does not contain an HMAC value.');
+    throw new ShopifyErrors.InvalidHmacError(
+      'Query does not contain an HMAC value.'
+    );
   }
   const { hmac, ...rest } = query;
   const localHmac = generateLocalHmac(rest);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,12 +1,14 @@
 import validateHmac from './hmac-validator';
 import validateShop from './shop-validator';
 import safeCompare from './safe-compare';
+import nonce from './nonce';
 
 const ShopifyUtilities = {
   validateHmac,
   validateShop,
   safeCompare,
+  nonce,
 };
 
 export default ShopifyUtilities;
-export { validateHmac, validateShop, safeCompare };
+export { validateHmac, validateShop, safeCompare, nonce };

--- a/src/utils/nonce.ts
+++ b/src/utils/nonce.ts
@@ -1,0 +1,11 @@
+export default function nonce(): string {
+  const length = 15;
+  let n = '';
+
+  for (let i = 0; i <= 3; i++) {
+    n += Math.round(+new Date() * Math.random());
+  }
+
+  const s = n.substr(n.length - length);
+  return s;
+}

--- a/src/utils/test/hmac-validator.test.ts
+++ b/src/utils/test/hmac-validator.test.ts
@@ -1,26 +1,29 @@
 import validateHmac from '../hmac-validator';
-import { AuthQueryObject } from '../../auth/types';
+import { AuthQuery } from '../../auth/types';
 import ShopifyErrors from '../../error';
 import { Context } from '../../context';
 import crypto from 'crypto';
 
 test('correctly validates query objects', () => {
   Context.API_SECRET_KEY = 'my super secret key';
-  const queryString = "code=some%20code%20goes%20here&shop=the%20shop%20URL&state=some%20nonce%20passed%20from%20auth&timestamp=a%20number%20as%20a%20string";
+  const queryString =
+    'code=some%20code%20goes%20here&shop=the%20shop%20URL&state=some%20nonce%20passed%20from%20auth&timestamp=a%20number%20as%20a%20string';
   const queryObjectWithoutHmac = {
-    code: "some code goes here",
-    shop: "the shop URL",
-    state: "some nonce passed from auth",
-    timestamp: "a number as a string"
+    code: 'some code goes here',
+    shop: 'the shop URL',
+    state: 'some nonce passed from auth',
+    timestamp: 'a number as a string',
   };
   const localHmac = crypto
     .createHmac('sha256', Context.API_SECRET_KEY)
     .update(queryString)
     .digest('hex');
 
-  const testQuery: AuthQueryObject = Object.assign(queryObjectWithoutHmac, { hmac: localHmac });
+  const testQuery: AuthQuery = Object.assign(queryObjectWithoutHmac, {
+    hmac: localHmac,
+  });
 
-  const badQuery: AuthQueryObject = {
+  const badQuery: AuthQuery = {
     code: 'some code goes here',
     hmac: 'incorrect_hmac_string',
     timestamp: 'a number as a string',

--- a/src/utils/test/nonce.test.ts
+++ b/src/utils/test/nonce.test.ts
@@ -1,0 +1,20 @@
+import nonce from '../nonce';
+
+test('nonce always returns a new 15 digit random number as a string', () => {
+  const firstNonce = nonce();
+  const secondNonce = nonce();
+
+  expect(firstNonce.length).toBe(15);
+  expect(secondNonce.length).toBe(15);
+  expect(typeof firstNonce).toBe('string');
+  expect(typeof secondNonce).toBe('string');
+});
+
+test('nonce always returns a unique value', () => {
+  for (let i = 0; i < 100; i++) {
+    const first = nonce();
+    const second = nonce();
+
+    expect(first).not.toEqual(second);
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -394,11 +394,6 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/create-cache-key-function@^26.5.0":
-  version "26.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/create-cache-key-function/-/create-cache-key-function-26.5.0.tgz#1d07947adc51ea17766d9f0ccf5a8d6ea94c47dc"
-  integrity sha512-DJ+pEBUIqarrbv1W/C39f9YH0rJ4wsXZ/VC6JafJPlHW2HOucKceeaqTOQj9MEDQZjySxMLkOq5mfXZXNZcmWw==
-
 "@jest/environment@^26.3.0":
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-26.3.0.tgz#e6953ab711ae3e44754a025f838bde1a7fd236a0"
@@ -636,15 +631,59 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/body-parser@*":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
+  integrity sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/connect@*":
+  version "3.4.33"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
+  integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
+  dependencies:
+    "@types/node" "*"
+
+"@types/cookies@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@types/cookies/-/cookies-0.7.5.tgz#aa42c9a9834724bffee597028da5319b38e85e84"
+  integrity sha512-3+TAFSm78O7/bAeYdB8FoYGntuT87vVP9JKuQRL8sRhv9313LP2SpHHL50VeFtnyjIcb3UELddMk5Yt0eOSOkg==
+  dependencies:
+    "@types/connect" "*"
+    "@types/express" "*"
+    "@types/keygrip" "*"
+    "@types/node" "*"
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
+"@types/express-serve-static-core@*":
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz#d9af025e925fc8b089be37423b8d1eac781be084"
+  integrity sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
+"@types/express@*":
+  version "4.17.9"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.9.tgz#f5f2df6add703ff28428add52bdec8a1091b0a78"
+  integrity sha512-SDzEIZInC4sivGIFY4Sz1GG6J9UObPwCInYJjko2jzOf/Imx/dlpume6Xxwj1ORL82tBbmN4cPDIDkLbWHk9hw==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.3"
@@ -672,7 +711,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.x":
+"@types/jest@26.x", "@types/jest@^26.0.15":
   version "26.0.15"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.15.tgz#12e02c0372ad0548e07b9f4e19132b834cb1effe"
   integrity sha512-s2VMReFXRg9XXxV+CW9e5Nz8fH2K1aEhwgjUqPPbQd7g95T0laAcvLv032EhFHIa5GHsZ8W7iJEQVaJq6k3Gog==
@@ -684,6 +723,16 @@
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+
+"@types/keygrip@*":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/keygrip/-/keygrip-1.0.2.tgz#513abfd256d7ad0bf1ee1873606317b33b1b2a72"
+  integrity sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==
+
+"@types/mime@*":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"
+  integrity sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==
 
 "@types/node-fetch@^2.5.7":
   version "2.5.7"
@@ -698,6 +747,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.10.1.tgz#cc323bad8e8a533d4822f45ce4e5326f36e42177"
   integrity sha512-aYNbO+FZ/3KGeQCEkNhHFRIzBOUgc7QvcVNKXbfnhDkSfwUv91JsQQa10rDgKSTSLkXZ1UIyPe4FJJNVgw1xWQ==
 
+"@types/node@^14.14.1":
+  version "14.14.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.1.tgz#b8d6e8a84b119ae51fd0593c71eb3a9dd31fea4e"
+  integrity sha512-D2/Xwp9c49JhIWq7SIrdvoYyGdq6yXkr5FTldN4rus9XljYFBul6P2epAID8xepOpL4ffcx09C05FZGK/1AIkw==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
@@ -708,10 +762,33 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.0.tgz#5f96562c1075ee715a5b138f0b7f591c1f40f6b8"
   integrity sha512-hiYA88aHiEIgDmeKlsyVsuQdcFn3Z2VuFd/Xm/HCnGnPD8UFU5BM128uzzRVVGEzKDKYUrRsRH9S2o+NUy/3IA==
 
+"@types/qs@*":
+  version "6.9.5"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.5.tgz#434711bdd49eb5ee69d90c1d67c354a9a8ecb18b"
+  integrity sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==
+
+"@types/range-parser@*":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
+  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/serve-static@*":
+  version "1.13.8"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.8.tgz#851129d434433c7082148574ffec263d58309c46"
+  integrity sha512-MoJhSQreaVoL+/hurAZzIm8wafFR6ajiTM1m4A0kv6AGeVBl4r4pOV8bGFrjjq1sGxDTnCoF8i22o0/aE5XCyA==
+  dependencies:
+    "@types/mime" "*"
+    "@types/node" "*"
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -1418,6 +1495,14 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+cookies@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.8.0.tgz#1293ce4b391740a8406e3c9870e828c4b54f3f90"
+  integrity sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==
+  dependencies:
+    depd "~2.0.0"
+    keygrip "~1.1.0"
+
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
@@ -1573,6 +1658,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -2242,9 +2332,9 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
 fastq@^1.6.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.8.0.tgz#550e1f9f59bbc65fe185cb6a9b4d95357107f481"
-  integrity sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.9.0.tgz#e16a72f338eaca48e91b5c23593bcc2ef66b7947"
+  integrity sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==
   dependencies:
     reusify "^1.0.4"
 
@@ -3478,6 +3568,13 @@ jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
   dependencies:
     array-includes "^3.1.1"
     object.assign "^4.1.0"
+
+keygrip@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.1.0.tgz#871b1681d5e159c62a445b0c74b615e0917e7226"
+  integrity sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==
+  dependencies:
+    tsscmp "1.0.6"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -4975,11 +5072,10 @@ tr46@^2.0.2:
     punycode "^2.1.1"
 
 ts-jest@^26.4.1:
-  version "26.4.3"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.3.tgz#d153a616033e7ec8544b97ddbe2638cbe38d53db"
-  integrity sha512-pFDkOKFGY+nL9v5pkhm+BIFpoAuno96ff7GMnIYr/3L6slFOS365SI0fGEVYx2RKGji5M2elxhWjDMPVcOCdSw==
+  version "26.4.4"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.4.tgz#61f13fb21ab400853c532270e52cc0ed7e502c49"
+  integrity sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==
   dependencies:
-    "@jest/create-cache-key-function" "^26.5.0"
     "@types/jest" "26.x"
     bs-logger "0.x"
     buffer-from "1.x"
@@ -5001,6 +5097,11 @@ tslib@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
   integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
+
+tsscmp@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
+  integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
 
 tsutils@^3.17.1:
   version "3.17.1"
@@ -5162,6 +5263,11 @@ uuid@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
+
+uuid@^8.3.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
+  integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.1"


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Adds the base OAuth functionality necessary for all app authorization. This PR provides methods for beginning the OAuth flow and validating the OAuth callback, both of which interact with `Context` and `Sessions`. 

### WHAT is this pull request doing?

`beginAuth` initializes a session with the necessary information (ie: shop and state), saves a cookie with the session id, and returns the generated auth route to begin the OAuth flow. 

`validateAuthCallback` uses the previously added utils to validate the received callback query and, if valid, will use the `HttpClient` to make the request to `admin/oauth/access_token` and update the session with the received token. If session is online access only, the session and cookie will be updated with the appropriate expiration date. Otherwise (offline access) the expiration date on the session remains `undefined`. 

Some necessary changes were made to the `Session` interface, as well as adding a custom `nonce` function for creating `state`. `nonce` uses the current time as a reference for generating strings of random numbers with a set length of 15 characters. 

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
