### PR TITLE
Set custom user agent on HttpClient requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 coverage/
 yarn-error.log
 docs/
+tsconfig.tsbuildinfo

--- a/src/clients/test/http_client.test.ts
+++ b/src/clients/test/http_client.test.ts
@@ -220,4 +220,17 @@ describe("HTTP client", () => {
     await expect(client.get({ path: '/url/path', extraHeaders: customHeaders })).resolves.toEqual(successResponse);
     assertHttpRequest('GET', domain, '/url/path', customHeaders);
   });
+
+  test("extends User-Agent if it is provided", async () => {
+    const client = new HttpClient(domain);
+
+    const customHeaders = {
+      'User-Agent': 'My agent',
+    };
+
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+
+    await expect(client.get({ path: '/url/path', extraHeaders: customHeaders })).resolves.toEqual(successResponse);
+    assertHttpRequest('GET', domain, '/url/path', { 'User-Agent': expect.stringContaining('My agent | Shopify App Dev Kit v') });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import { Context } from './context';
 import { ContextParams } from './types';
-import ShopifyError from './error';
+import ShopifyErrors from './error';
 
 export {
   Context,
   ContextParams,
-  ShopifyError,
+  ShopifyErrors,
 };

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,3 @@
+import { version } from '../package.json';
+
+export const SHOPIFY_APP_DEV_KIT_VERSION = version;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "strictNullChecks": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
+    "resolveJsonModule": true,
     "lib": [
       "dom",
       "dom.iterable",
@@ -36,7 +37,8 @@
   },
   "include": [
     "./src/**/*.ts",
-    "./src/**/*.tsx"
+    "./src/**/*.tsx",
+    "./package.json"
   ],
   "exclude": [
     "**/*.test.ts",


### PR DESCRIPTION
### WHY are these changes introduced?

We want to be able to track requests made with apps created with the dev kit, so we should tag them with information on the library.

### WHAT is this pull request doing?

Adds a version to the library and changes the `User-Agent` on all HTTP requests to indicate the library / node versions.

## Type of change

- [X] Minor: New feature (non-breaking change which adds functionality)
