### PR TITLE
Update data parameter to allow different data types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,5 +18,6 @@ module.exports = {
     ],
     "rules": {
         "object-curly-spacing": ["error", "always"]
-    }
+    },
+    "ignorePatterns": ["dist/"]
 };

--- a/src/clients/rest/test/rest_client.test.ts
+++ b/src/clients/rest/test/rest_client.test.ts
@@ -1,7 +1,9 @@
 import '../../../test/test_helper';
 import { ShopifyHeader } from '../../../types';
+import { DataType } from '../../http_client';
 import { assertHttpRequest } from '../../test/test_helper';
 import { RestClient } from '../rest_client';
+import querystring from 'querystring';
 
 const domain = 'test-shop'; // Omitting the myshopify.com part to fail if real requests are made
 const successResponse = {
@@ -19,11 +21,11 @@ describe("REST client", () => {
 
     fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
-    await expect(client.get('products')).resolves.toEqual(successResponse);
+    await expect(client.get({ path: 'products' })).resolves.toEqual(successResponse);
     assertHttpRequest('GET', domain, '/admin/api/unstable/products.json');
   });
 
-  it("can make POST request", async () => {
+  it("can make POST request with JSON data", async () => {
     const client = new RestClient(domain, 'dummy-token');
 
     fetchMock.mockResponseOnce(JSON.stringify(successResponse));
@@ -33,11 +35,11 @@ describe("REST client", () => {
       amount: 10,
     };
 
-    await expect(client.post('products', postData)).resolves.toEqual(successResponse);
-    assertHttpRequest('POST', domain, '/admin/api/unstable/products.json', {}, postData);
+    await expect(client.post({ path: 'products', type: DataType.JSON, data: postData })).resolves.toEqual(successResponse);
+    assertHttpRequest('POST', domain, '/admin/api/unstable/products.json', { 'Content-Type': DataType.JSON.toString() }, JSON.stringify(postData));
   });
 
-  it("can make PUT request", async () => {
+  it("can make POST request with form data", async () => {
     const client = new RestClient(domain, 'dummy-token');
 
     fetchMock.mockResponseOnce(JSON.stringify(successResponse));
@@ -47,8 +49,22 @@ describe("REST client", () => {
       amount: 10,
     };
 
-    await expect(client.put('products/123', postData)).resolves.toEqual(successResponse);
-    assertHttpRequest('PUT', domain, '/admin/api/unstable/products/123.json', {}, postData);
+    await expect(client.post({ path: 'products', type: DataType.URLEncoded, data: postData })).resolves.toEqual(successResponse);
+    assertHttpRequest('POST', domain, '/admin/api/unstable/products.json', { 'Content-Type': DataType.URLEncoded.toString() }, querystring.stringify(postData));
+  });
+
+  it("can make PUT request with JSON data", async () => {
+    const client = new RestClient(domain, 'dummy-token');
+
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+
+    const putData = {
+      title: 'Test product',
+      amount: 10,
+    };
+
+    await expect(client.put({ path: 'products/123', type: DataType.JSON, data: putData })).resolves.toEqual(successResponse);
+    assertHttpRequest('PUT', domain, '/admin/api/unstable/products/123.json', { 'Content-Type': DataType.JSON.toString() }, JSON.stringify(putData));
   });
 
   it("can make DELETE request", async () => {
@@ -56,20 +72,20 @@ describe("REST client", () => {
 
     fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
-    await expect(client.delete('products/123')).resolves.toEqual(successResponse);
+    await expect(client.delete({ path: 'products/123' })).resolves.toEqual(successResponse);
     assertHttpRequest('DELETE', domain, '/admin/api/unstable/products/123.json');
   });
 
   it("merges custom headers with the default ones", async () => {
     const client = new RestClient(domain, 'dummy-token');
 
-    const customHeaders: {[key: string]: string} = {
+    const customHeaders: Record<string, string> = {
       'X-Not-A-Real-Header': 'some_value',
     };
 
     fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
-    await expect(client.get('products', customHeaders)).resolves.toEqual(successResponse);
+    await expect(client.get({ path: 'products', extraHeaders: customHeaders })).resolves.toEqual(successResponse);
 
     customHeaders[ShopifyHeader.AccessToken] = 'dummy-token';
     assertHttpRequest('GET', domain, '/admin/api/unstable/products.json', customHeaders);

--- a/src/clients/test/http_client.test.ts
+++ b/src/clients/test/http_client.test.ts
@@ -1,8 +1,9 @@
 import '../../test/test_helper';
 import { assertHttpRequest } from './test_helper';
 
-import { HttpClient } from '../http_client';
+import { HttpClient, DataType } from '../http_client';
 import ShopifyErrors from '../../error';
+import querystring from 'querystring';
 
 const domain = 'test-shop'; // Omitting the myshopify.com part to fail if real requests are made
 const successResponse = { message: "Your HTTP request was successful!" };
@@ -13,11 +14,11 @@ describe("HTTP client", () => {
 
     fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
-    await expect(client.get('/url/path')).resolves.toEqual(successResponse);
+    await expect(client.get({ path: '/url/path' })).resolves.toEqual(successResponse);
     assertHttpRequest('GET', domain, '/url/path');
   });
 
-  test("can make POST request", async () => {
+  test("can make POST request with type JSON", async () => {
     const client = new HttpClient(domain);
 
     fetchMock.mockResponseOnce(JSON.stringify(successResponse));
@@ -27,11 +28,17 @@ describe("HTTP client", () => {
       amount: 10,
     };
 
-    await expect(client.post('/url/path', postData)).resolves.toEqual(successResponse);
-    assertHttpRequest('POST', domain, '/url/path', {}, postData);
+    const postParams = {
+      path: '/url/path',
+      type: DataType.JSON,
+      data: postData
+    };
+
+    await expect(client.post(postParams)).resolves.toEqual(successResponse);
+    assertHttpRequest('POST', domain, '/url/path', { 'Content-Type': DataType.JSON.toString() }, JSON.stringify(postData));
   });
 
-  test("can make PUT request", async () => {
+  test("can make POST request with type JSON and data is already formatted", async () => {
     const client = new HttpClient(domain);
 
     fetchMock.mockResponseOnce(JSON.stringify(successResponse));
@@ -41,8 +48,117 @@ describe("HTTP client", () => {
       amount: 10,
     };
 
-    await expect(client.put('/url/path/123', postData)).resolves.toEqual(successResponse);
-    assertHttpRequest('PUT', domain, '/url/path/123', {}, postData);
+    const postParams = {
+      path: '/url/path',
+      type: DataType.JSON,
+      data: JSON.stringify(postData)
+    };
+
+    await expect(client.post(postParams)).resolves.toEqual(successResponse);
+    assertHttpRequest('POST', domain, '/url/path', { 'Content-Type': DataType.JSON.toString() }, JSON.stringify(postData));
+  });
+
+  test("can make POST request with zero-length JSON", async () => {
+    const client = new HttpClient(domain);
+
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+
+    const postParams = {
+      path: '/url/path',
+      type: DataType.JSON,
+      data: ''
+    };
+
+    await expect(client.post(postParams)).resolves.toEqual(successResponse);
+    assertHttpRequest('POST', domain, '/url/path', {}, null);
+  });
+
+  test("can make POST request with form-data type", async () => {
+    const client = new HttpClient(domain);
+
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+
+    const postData = {
+      title: 'Test product',
+      amount: 10,
+    };
+
+    const postParams = {
+      path: '/url/path',
+      type: DataType.URLEncoded,
+      data: postData
+    };
+
+    await expect(client.post(postParams)).resolves.toEqual(successResponse);
+    assertHttpRequest('POST', domain, '/url/path', { 'Content-Type': DataType.URLEncoded.toString() }, querystring.stringify(postData));
+  });
+
+  test("can make POST request with form-data type and data is already formatted", async () => {
+    const client = new HttpClient(domain);
+
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+
+    const postData = {
+      title: 'Test product',
+      amount: 10,
+    };
+
+    const postParams = {
+      path: '/url/path',
+      type: DataType.URLEncoded,
+      data: querystring.stringify(postData)
+    };
+
+    await expect(client.post(postParams)).resolves.toEqual(successResponse);
+    assertHttpRequest('POST', domain, '/url/path', { 'Content-Type': DataType.URLEncoded.toString() }, querystring.stringify(postData));
+  });
+
+  test("can make POST request with GraphQL type", async () => {
+    const client = new HttpClient(domain);
+
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+
+    const graphql_query = `
+      query {
+        webhookSubscriptions(first:5) {
+          edges {
+            node {
+              id
+              endpoint
+            }
+          }
+        }
+      }
+    `;
+
+    const postParams = {
+      path: '/url/path',
+      type: DataType.GraphQL,
+      data: graphql_query
+    };
+
+    await expect(client.post(postParams)).resolves.toEqual(successResponse);
+    assertHttpRequest('POST', domain, '/url/path', { 'Content-Type': DataType.GraphQL.toString() }, graphql_query);
+  });
+
+  test("can make PUT request with type JSON", async () => {
+    const client = new HttpClient(domain);
+
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+
+    const putData = {
+      title: 'Test product',
+      amount: 10,
+    };
+
+    const putParams = {
+      path: '/url/path/123',
+      type: DataType.JSON,
+      data: putData
+    }
+
+    await expect(client.put(putParams)).resolves.toEqual(successResponse);
+    assertHttpRequest('PUT', domain, '/url/path/123', { 'Content-Type': DataType.JSON.toString() }, JSON.stringify(putData));
   });
 
   test("can make DELETE request", async () => {
@@ -50,7 +166,7 @@ describe("HTTP client", () => {
 
     fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
-    await expect(client.delete('/url/path/123')).resolves.toEqual(successResponse);
+    await expect(client.delete({ path: '/url/path/123' })).resolves.toEqual(successResponse);
     assertHttpRequest('DELETE', domain, '/url/path/123');
   });
 
@@ -76,7 +192,7 @@ describe("HTTP client", () => {
         fetchMock.mockRejectOnce(() => Promise.reject());
       }
 
-      const expectResult = expect(client.get('/url/path')).rejects;
+      const expectResult = expect(client.get({ path: '/url/path' })).rejects;
       await expectResult.toBeInstanceOf(expectedError);
       // Make sure we return the HTTP response code in the fallback error
       if (expectedError === ShopifyErrors.HttpResponseError) {
@@ -101,7 +217,7 @@ describe("HTTP client", () => {
 
     fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
-    await expect(client.get('/url/path', customHeaders)).resolves.toEqual(successResponse);
+    await expect(client.get({ path: '/url/path', extraHeaders: customHeaders })).resolves.toEqual(successResponse);
     assertHttpRequest('GET', domain, '/url/path', customHeaders);
   });
 });

--- a/src/clients/test/test_helper.ts
+++ b/src/clients/test/test_helper.ts
@@ -1,19 +1,18 @@
-import querystring, { ParsedUrlQueryInput } from 'querystring';
-import fetchMock from  'jest-fetch-mock';
+import fetchMock from 'jest-fetch-mock';
 
 export function assertHttpRequest(
   method: string,
   domain: string,
   path: string,
   headers: Record<string, unknown> = {},
-  data: ParsedUrlQueryInput | null = null
+  data: string | null = null
 ): void {
   expect(fetchMock).toBeCalledWith(
     `https://${domain}${path}`,
     expect.objectContaining({
       method: method,
       headers: expect.objectContaining(headers),
-      body: data ? querystring.stringify(data) : null,
+      body: data,
     })
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,7 @@
 import { Context } from './context';
 import { ContextParams } from './types';
-import { ShopifyError } from './error';
+import ShopifyError from './error';
 
-const Shopify = {
-  ShopifyError,
-};
-
-export default Shopify;
 export {
   Context,
   ContextParams,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Different API requests expect different body data types (URL encoded form data, JSON, GraphQL string).

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Updating the `data` parameter passed to the `HttpClient` (and by inheritance, the `RestClient`) to enable the developer to set the data type (which will be used for `Content-Type` header) and the correspondingly-encoded data.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [x] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added/updated tests for this change