### PR TITLE
Validate domain in HTTP client

### DIFF
--- a/src/clients/http_client.ts
+++ b/src/clients/http_client.ts
@@ -3,6 +3,7 @@ import querystring, { ParsedUrlQueryInput } from 'querystring';
 import { Method, StatusCode } from '@shopify/network';
 import ShopifyErrors from '../error';
 import { SHOPIFY_APP_DEV_KIT_VERSION } from '../version';
+import { validateShop } from '../utils';
 
 type HeaderParams = Record<string, string>;
 
@@ -35,6 +36,10 @@ class HttpClient {
   static readonly RETRY_WAIT_TIME = 1000; // 1 second
 
   public constructor(private domain: string) {
+    if (!validateShop(domain)) {
+      throw new ShopifyErrors.InvalidShopError(`Domain ${domain} is not valid`);
+    }
+
     this.domain = domain;
   }
 

--- a/src/clients/rest/test/rest_client.test.ts
+++ b/src/clients/rest/test/rest_client.test.ts
@@ -5,7 +5,7 @@ import { assertHttpRequest } from '../../test/test_helper';
 import { RestClient } from '../rest_client';
 import querystring from 'querystring';
 
-const domain = 'test-shop'; // Omitting the myshopify.com part to fail if real requests are made
+const domain = 'test-shop.myshopify.io';
 const successResponse = {
   products: [
     {

--- a/src/clients/test/http_client.test.ts
+++ b/src/clients/test/http_client.test.ts
@@ -5,13 +5,17 @@ import { HttpClient, DataType, HeaderParams } from '../http_client';
 import ShopifyErrors from '../../error';
 import querystring from 'querystring';
 
-const domain = 'test-shop'; // Omitting the myshopify.com part to fail if real requests are made
+const domain = 'test-shop.myshopify.io';
 const successResponse = { message: "Your HTTP request was successful!" };
 
 const originalRetryTime = HttpClient.RETRY_WAIT_TIME;
 describe("HTTP client", () => {
   afterAll(() => {
     setRestClientRetryTime(originalRetryTime);
+  });
+
+  it("validates the given domain", () => {
+    expect(() => new HttpClient('invalid domain')).toThrow(ShopifyErrors.InvalidShopError);
   });
 
   it("can make GET request", async () => {

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,6 +1,7 @@
 class ShopifyError extends Error {}
 
 class InvalidHmacError extends ShopifyError {}
+class InvalidShopError extends ShopifyError {}
 
 class SafeCompareError extends ShopifyError {}
 
@@ -18,6 +19,7 @@ class HttpThrottlingError extends HttpRetriableError {}
 const ShopifyErrors = {
   ShopifyError,
   InvalidHmacError,
+  InvalidShopError,
   SafeCompareError,
   HttpRequestError,
   HttpMaxRetriesError,

--- a/src/utils/shop-validator.ts
+++ b/src/utils/shop-validator.ts
@@ -1,4 +1,4 @@
 export default function validateShop(shop: string): boolean {
-  const shopUrlRegex = /^https:\/\/[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.com[/]*$/;
+  const shopUrlRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.(com|io)[/]*$/;
   return shopUrlRegex.test(shop);
 }

--- a/src/utils/test/shop-validator.test.ts
+++ b/src/utils/test/shop-validator.test.ts
@@ -5,18 +5,18 @@ test('returns a boolean value', () => {
 });
 
 test('returns true for valid shop urls', () => {
-  const shopUrl = 'https://someshop.myshopify.com';
+  const shopUrl = 'someshop.myshopify.io';
   expect(validateShop(shopUrl)).toBe(true);
 });
 
 test('returns false for invalid shop urls', () => {
-  const shopUrl = 'https://notshopify.com';
-  const anotherShop = 'https://-invalid.myshopify.com';
+  const shopUrl = 'notshopify.com';
+  const anotherShop = '-invalid.myshopify.io';
   expect(validateShop(shopUrl)).toBe(false);
   expect(validateShop(anotherShop)).toBe(false);
 });
 
-test("returns false for invalid shop urls, even if they contain the string 'myshopify.com'", () => {
-  const shopUrl = 'https://notshopify.myshopify.com.org/potato';
+test("returns false for invalid shop urls, even if they contain the string 'myshopify.io'", () => {
+  const shopUrl = 'notshopify.myshopify.io.org/potato';
   expect(validateShop(shopUrl)).toBe(false);
 });


### PR DESCRIPTION
### WHY are these changes introduced?

The HTTP client - and by extension, the REST client - relies on the domain of the shop on which commands will be run, so we should make sure that the domain used for a client is a valid one before making requests.

### WHAT is this pull request doing?

Validating the given domain using the utils function to ensure that the requests are going to a valid Shopify location.

## Type of change

- [X] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have added/updated tests for this change
