### PR TITLE
Follow Retry-After for HTTP retries

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -7,13 +7,13 @@ class SafeCompareError extends ShopifyError {}
 class HttpRequestError extends ShopifyError {}
 class HttpMaxRetriesError extends ShopifyError {}
 class HttpResponseError extends ShopifyError {
-  public constructor(message: string, readonly code: number, readonly statusText: string) {
-    super(message);
-  }
+  public constructor(message: string, readonly code: number, readonly statusText: string) { super(message); }
 }
 class HttpRetriableError extends ShopifyError {}
 class HttpInternalError extends HttpRetriableError {}
-class HttpThrottlingError extends HttpRetriableError {}
+class HttpThrottlingError extends HttpRetriableError {
+  public constructor(message: string, readonly retryAfter?: number) { super(message); }
+}
 
 const ShopifyErrors = {
   ShopifyError,


### PR DESCRIPTION
### WHY are these changes introduced?

When throttling requests in the Admin API, Shopify will send back the `Retry-After` HTTP header. The client should follow that header when it's present in `429` responses.

### WHAT is this pull request doing?

If the header is returned and has a value, the HTTP client will wait for that long before attempting a retry, defaulting to the previous behaviour of waiting for 1s if the header is not present in the response.

## Type of change

- [X] Minor: New feature (non-breaking change which adds functionality)


## Checklist

- [X] I have added/updated tests for this change
