### PR TITLE
Add method to retrieve current session to Utils

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -36,7 +36,6 @@ interface ContextInterface extends ContextParams {
   /**
    * Throws error if context has not been initialized.
    */
-
   throwIfUnitialized(): void | never;
 }
 
@@ -46,6 +45,7 @@ const Context: ContextInterface = {
   SCOPES: [],
   HOST_NAME: '',
   API_VERSION: ApiVersion.Unstable,
+  IS_EMBEDDED_APP: true,
   SESSION_STORAGE: new MemorySessionStorage(),
 
   initialize(params: ContextParams): void {
@@ -75,6 +75,7 @@ const Context: ContextInterface = {
     this.SCOPES = params.SCOPES;
     this.HOST_NAME = params.HOST_NAME;
     this.API_VERSION = params.API_VERSION;
+    this.IS_EMBEDDED_APP = params.IS_EMBEDDED_APP;
 
     if (params.SESSION_STORAGE) {
       this.SESSION_STORAGE = params.SESSION_STORAGE;

--- a/src/test/context.test.ts
+++ b/src/test/context.test.ts
@@ -5,12 +5,16 @@ import { Context } from '../context';
 import { ApiVersion, ContextParams } from '../types';
 import { CustomSessionStorage, Session } from '../auth/session';
 
+jest.mock('cookies');
+import Cookies from 'cookies';
+
 const validParams: ContextParams = {
   API_KEY: 'api_key',
   API_SECRET_KEY: 'secret_key',
   SCOPES: ['scope'],
   HOST_NAME: 'host_name',
   API_VERSION: ApiVersion.Unstable,
+  IS_EMBEDDED_APP: true,
 };
 
 const originalWarn = console.warn;
@@ -18,6 +22,7 @@ const originalWarn = console.warn;
 describe('Context object', () => {
   afterEach(() => {
     console.warn = originalWarn;
+    (Cookies as any).mockClear(); // eslint-disable-line @typescript-eslint/no-explicit-any
   });
 
   it('can initialize and update context', () => {
@@ -76,6 +81,7 @@ describe('Context object', () => {
       SCOPES: [],
       HOST_NAME: '',
       API_VERSION: ApiVersion.Unstable,
+      IS_EMBEDDED_APP: true,
     };
     expect(() => Context.initialize(empty)).toThrow(ShopifyErrors.ShopifyError);
   });
@@ -113,14 +119,9 @@ describe('Context object', () => {
       }
     );
 
-    Context.initialize({
-      API_KEY: 'api_key',
-      API_SECRET_KEY: 'api_secret_key',
-      SCOPES: ['do_one_thing', 'do_something_else'],
-      HOST_NAME: 'host_name',
-      API_VERSION: ApiVersion.Unstable,
-      SESSION_STORAGE: storage,
-    });
+    const params = Object.assign({}, validParams);
+    params.SESSION_STORAGE = storage;
+    Context.initialize(params);
 
     await expect(Context.storeSession(session)).resolves.toEqual(true);
     expect(store_called).toBe(true);

--- a/src/test/test_helper.ts
+++ b/src/test/test_helper.ts
@@ -3,6 +3,7 @@ enableFetchMocks();
 
 import { Context } from '../context';
 import { ApiVersion } from '../types';
+import { MemorySessionStorage } from '../auth/session';
 
 beforeEach(() => {
   // We want to reset the Context object on every run so that tests start with a consistent state
@@ -12,6 +13,8 @@ beforeEach(() => {
     SCOPES: ['test_scope'],
     HOST_NAME: 'test_host_name',
     API_VERSION: ApiVersion.Unstable,
+    IS_EMBEDDED_APP: false,
+    SESSION_STORAGE: new MemorySessionStorage(),
   });
 
   fetchMock.mockRestore();

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface ContextParams {
   SCOPES: string[],
   HOST_NAME: string,
   API_VERSION: ApiVersion,
+  IS_EMBEDDED_APP: boolean,
   SESSION_STORAGE?: SessionStorage,
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,14 +1,16 @@
 import validateHmac from './hmac-validator';
 import validateShop from './shop-validator';
 import safeCompare from './safe-compare';
+import loadCurrentSession from './load-current-session';
 import nonce from './nonce';
 
 const ShopifyUtilities = {
   validateHmac,
   validateShop,
   safeCompare,
+  loadCurrentSession,
   nonce,
 };
 
 export default ShopifyUtilities;
-export { validateHmac, validateShop, safeCompare, nonce };
+export { validateHmac, validateShop, safeCompare, loadCurrentSession, nonce };

--- a/src/utils/load-current-session.ts
+++ b/src/utils/load-current-session.ts
@@ -1,0 +1,37 @@
+import http from 'http';
+import Cookies from 'cookies';
+import { ShopifyOAuth } from '../auth/oauth/oauth';
+import { Context } from '../context';
+import { Session } from '../auth/session';
+
+/**
+ * Loads the current user's session, based on the given request.
+ *
+ * @param req Current HTTP request
+ * @param res Current HTTP response
+ */
+export default async function loadCurrentSession(request: http.IncomingMessage, response: http.ServerResponse): Promise<Session | null> {
+  Context.throwIfUnitialized();
+
+  let session: Session | null = null;
+
+  if (Context.IS_EMBEDDED_APP) {
+    // TODO load session from JWT token
+  }
+  else {
+    const cookies = new Cookies(request, response, {
+      keys: [Context.API_SECRET_KEY],
+    });
+
+    const sessionCookie: string | undefined = cookies.get(
+      ShopifyOAuth.SESSION_COOKIE_NAME,
+      { signed: true }
+    );
+
+    if (sessionCookie) {
+      session = await Context.loadSession(sessionCookie);
+    }
+  }
+
+  return session;
+}

--- a/src/utils/test/load-current-session.test.ts
+++ b/src/utils/test/load-current-session.test.ts
@@ -1,0 +1,34 @@
+import '../../test/test_helper';
+
+import { Context } from '../../context';
+import { ApiVersion, ContextParams } from '../../types';
+import { Session } from '../../auth/session';
+import loadCurrentSession from '../load-current-session';
+import http from 'http';
+
+jest.mock('cookies');
+import Cookies from 'cookies';
+
+test("can load the current session from cookies for non-embedded apps", async () => {
+  const params: ContextParams = {
+    API_KEY: 'api_key',
+    API_SECRET_KEY: 'secret_key',
+    SCOPES: ['scope'],
+    HOST_NAME: 'host_name',
+    API_VERSION: ApiVersion.Unstable,
+    IS_EMBEDDED_APP: false,
+  };
+  Context.initialize(params);
+
+  const req = {} as http.IncomingMessage;
+  const res = {} as http.ServerResponse;
+
+  const cookieId = '1234-this-is-a-cookie-session-id';
+
+  const session = new Session(cookieId);
+  await expect(Context.storeSession(session)).resolves.toEqual(true);
+
+  Cookies.prototype.get.mockImplementation(() => cookieId);
+
+  await expect(loadCurrentSession(req, res)).resolves.toEqual(session);
+});

--- a/src/utils/test/shop-validator.test.ts
+++ b/src/utils/test/shop-validator.test.ts
@@ -1,12 +1,10 @@
 import validateShop from '../shop-validator';
 
-test('returns a boolean value', () => {
-  expect(typeof validateShop('someshop')).toBe('boolean');
-});
-
 test('returns true for valid shop urls', () => {
-  const shopUrl = 'someshop.myshopify.io';
+  const shopUrl = 'someshop.myshopify.com';
+  const devUrl = 'devshop.myshopify.io';
   expect(validateShop(shopUrl)).toBe(true);
+  expect(validateShop(devUrl)).toBe(true);
 });
 
 test('returns false for invalid shop urls', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Context is a central class to access the necessary information from Shopify, so it follows that developers will likely expect to be able to retrieve the current session easily. After OAuth, the sessions will be automatically generated by the library, so developers won't have control over what session ids are being used.

We should therefore make it easy for them to retrieve whatever session applies to the current request (if any) to easily expose the session information.

### WHAT is this pull request doing?

Adding a `loadCurrentSession` to Context, which will decide based on a new config flag `IS_EMBEDDED_APP` whether to try and load the session id from cookies or the JWT token, and call `loadSession` on the appropriate id.
