### PR TITLE
Get current JWT session support

### DIFF
--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -23,6 +23,7 @@ const ShopifyOAuth = {
 
     const cookies = new Cookies(request, response, {
       keys: [Context.API_SECRET_KEY],
+      secure: true,
     });
 
     const state = utils.nonce();
@@ -37,6 +38,8 @@ const ShopifyOAuth = {
     cookies.set(ShopifyOAuth.SESSION_COOKIE_NAME, session.id, {
       signed: true,
       expires: new Date(Date.now() + 60000),
+      sameSite: 'none',
+      secure: true,
     });
 
     const query = {
@@ -61,9 +64,10 @@ const ShopifyOAuth = {
 
     const cookies = new Cookies(request, response, {
       keys: [Context.API_SECRET_KEY],
+      secure: true,
     });
 
-    const currentSession = await utils.loadCurrentSession(request, response);
+    const currentSession = await utils.loadCurrentSession(request, response, true);
 
     if (!currentSession) {
       throw new ShopifyErrors.SessionNotFound(
@@ -105,6 +109,8 @@ const ShopifyOAuth = {
         signed: true,
         domain: Context.HOST_NAME,
         expires: sessionExpiration,
+        sameSite: 'none',
+        secure: true,
       });
     } else {
       const responseBody = postResponse.body as AccessTokenResponse;

--- a/src/auth/session/session.ts
+++ b/src/auth/session/session.ts
@@ -1,4 +1,5 @@
 import { OnlineAccessInfo } from '../types';
+
 /**
  * Stores App information from logged in merchants so they can make authenticated requests to the Admin API.
  */
@@ -12,6 +13,20 @@ class Session {
   public onlineAccesInfo?: OnlineAccessInfo;
 
   constructor(readonly id: string) {}
+
+  public static async cloneSession(session: Session, newId: string): Promise<Session> {
+    const newSession = new Session(newId);
+
+    newSession.shop = session.shop;
+    newSession.state = session.state;
+    newSession.scope = session.scope;
+    newSession.expires = session.expires;
+    newSession.isOnline = session.isOnline;
+    newSession.accessToken = session.accessToken;
+    newSession.onlineAccesInfo = session.onlineAccesInfo;
+
+    return newSession;
+  }
 }
 
 export { Session };

--- a/src/error.ts
+++ b/src/error.ts
@@ -3,6 +3,7 @@ class ShopifyError extends Error {}
 class InvalidHmacError extends ShopifyError {}
 class InvalidShopError extends ShopifyError {}
 class InvalidJwtError extends ShopifyError {}
+class MissingJwtTokenError extends ShopifyError {}
 
 class SafeCompareError extends ShopifyError {}
 class UninitializedContextError extends ShopifyError {}
@@ -34,6 +35,7 @@ const ShopifyErrors = {
   InvalidHmacError,
   InvalidShopError,
   InvalidJwtError,
+  MissingJwtTokenError,
   SafeCompareError,
   HttpRequestError,
   HttpMaxRetriesError,

--- a/src/utils/load-current-session.ts
+++ b/src/utils/load-current-session.ts
@@ -3,31 +3,60 @@ import Cookies from 'cookies';
 import { ShopifyOAuth } from '../auth/oauth/oauth';
 import { Context } from '../context';
 import { Session } from '../auth/session';
+import decodeSessionToken from './decode-session-token';
+import ShopifyErrors from '../error';
 
 /**
  * Loads the current user's session, based on the given request.
  *
  * @param req Current HTTP request
  * @param res Current HTTP response
+ * @param isOauthCall Whether to expect an ongoing OAuth flow. If there is one and a session token is given,
+ *                    the session will be converted for future uses. Generally not necessary if using default OAuth
  */
-export default async function loadCurrentSession(request: http.IncomingMessage, response: http.ServerResponse): Promise<Session | null> {
+export default async function loadCurrentSession(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  isOauthCall = false
+): Promise<Session | null> {
   Context.throwIfUnitialized();
+
+  const cookies = new Cookies(request, response, {
+    secure: true,
+    keys: [Context.API_SECRET_KEY],
+  });
+  const sessionCookie: string | undefined = cookies.get(
+    ShopifyOAuth.SESSION_COOKIE_NAME,
+    { signed: true }
+  );
 
   let session: Session | null = null;
 
-  if (Context.IS_EMBEDDED_APP) {
-    // TODO load session from JWT
+  if (!isOauthCall && Context.IS_EMBEDDED_APP) {
+    const authHeader = request.headers['authorization'];
+    if (authHeader) {
+      const matches = authHeader.match(/^Bearer (.+)$/);
+      if (!matches) {
+        throw new ShopifyErrors.MissingJwtTokenError("Missing Bearer token in authorization header");
+      }
+
+      const jwtPayload = decodeSessionToken(matches[1]);
+      session = await Context.loadSession(jwtPayload.sid);
+
+      // JWT session does not exist. If there is an OAuth session, transfer it to a new JWT one
+      if (!session && sessionCookie) {
+        const oauthSession = await Context.loadSession(sessionCookie);
+        if (oauthSession) {
+          session = await Session.cloneSession(oauthSession, jwtPayload.sid);
+          session.expires = new Date(jwtPayload.exp * 1000);
+
+          await Context.storeSession(session);
+          await Context.deleteSession(oauthSession.id);
+        }
+      }
+    }
   }
   else {
-    const cookies = new Cookies(request, response, {
-      keys: [Context.API_SECRET_KEY],
-    });
-
-    const sessionCookie: string | undefined = cookies.get(
-      ShopifyOAuth.SESSION_COOKIE_NAME,
-      { signed: true }
-    );
-
     if (sessionCookie) {
       session = await Context.loadSession(sessionCookie);
     }

--- a/src/utils/test/load-current-session.test.ts
+++ b/src/utils/test/load-current-session.test.ts
@@ -1,34 +1,142 @@
 import '../../test/test_helper';
 
-import { Context } from '../../context';
-import { ApiVersion, ContextParams } from '../../types';
-import { Session } from '../../auth/session';
-import loadCurrentSession from '../load-current-session';
 import http from 'http';
+import jwt from 'jsonwebtoken';
+
+import { Context } from '../../context';
+import { Session } from '../../auth/session';
+import ShopifyErrors from '../../error';
+import { JwtPayload } from '../decode-session-token';
+import loadCurrentSession from '../load-current-session';
 
 jest.mock('cookies');
 import Cookies from 'cookies';
 
-test("can load the current session from cookies for non-embedded apps", async () => {
-  const params: ContextParams = {
-    API_KEY: 'api_key',
-    API_SECRET_KEY: 'secret_key',
-    SCOPES: ['scope'],
-    HOST_NAME: 'host_name',
-    API_VERSION: ApiVersion.Unstable,
-    IS_EMBEDDED_APP: false,
-  };
-  Context.initialize(params);
+describe("loadCurrentSession", () => {
+  let jwtPayload: JwtPayload;
 
-  const req = {} as http.IncomingMessage;
-  const res = {} as http.ServerResponse;
+  beforeEach(() => {
+    jwtPayload = {
+      iss: "test-shop.myshopify.io/admin",
+      dest: "test-shop.myshopify.io",
+      aud: Context.API_KEY,
+      sub: "1",
+      exp: Date.now() / 1000 + 3600,
+      nbf: 1234,
+      iat: 1234,
+      jti: "4321",
+      sid: "abc123",
+    };
+  });
 
-  const cookieId = '1234-this-is-a-cookie-session-id';
+  it("gets the current session from cookies for non-embedded apps", async () => {
+    Context.IS_EMBEDDED_APP = false;
+    Context.initialize(Context);
 
-  const session = new Session(cookieId);
-  await expect(Context.storeSession(session)).resolves.toEqual(true);
+    const req = {} as http.IncomingMessage;
+    const res = {} as http.ServerResponse;
 
-  Cookies.prototype.get.mockImplementation(() => cookieId);
+    const cookieId = '1234-this-is-a-cookie-session-id';
 
-  await expect(loadCurrentSession(req, res)).resolves.toEqual(session);
+    const session = new Session(cookieId);
+    await expect(Context.storeSession(session)).resolves.toEqual(true);
+
+    Cookies.prototype.get.mockImplementation(() => cookieId);
+
+    await expect(loadCurrentSession(req, res)).resolves.toEqual(session);
+  });
+
+  it("loads nothing if there is no session for non-embedded apps", async () => {
+    Context.IS_EMBEDDED_APP = false;
+    Context.initialize(Context);
+
+    const req = {} as http.IncomingMessage;
+    const res = {} as http.ServerResponse;
+
+    Cookies.prototype.get.mockImplementation(() => null);
+
+    await expect(loadCurrentSession(req, res)).resolves.toBeNull();
+  });
+
+  it("gets the current session from JWT token for embedded apps", async () => {
+    Context.IS_EMBEDDED_APP = true;
+    Context.initialize(Context);
+
+    const token = jwt.sign(jwtPayload, Context.API_SECRET_KEY, { algorithm: 'HS256' });
+    const req = {
+      headers: {
+        "authorization": `Bearer ${token}`,
+      }
+    } as http.IncomingMessage;
+    const res = {} as http.ServerResponse;
+
+    const session = new Session(jwtPayload.sid);
+    await expect(Context.storeSession(session)).resolves.toEqual(true);
+
+    await expect(loadCurrentSession(req, res)).resolves.toEqual(session);
+  });
+
+  it("converts an OAuth session into a JWT one", async () => {
+    Context.IS_EMBEDDED_APP = true;
+    Context.initialize(Context);
+
+    const token = jwt.sign(jwtPayload, Context.API_SECRET_KEY, { algorithm: 'HS256' });
+    const req = {
+      headers: {
+        "authorization": `Bearer ${token}`,
+      }
+    } as http.IncomingMessage;
+    const res = {} as http.ServerResponse;
+
+    const cookieId = '1234-this-is-a-cookie-session-id';
+
+    // We expect to find the OAuth cookie session, which will be deleted after we migrate it over to a JWT one
+    const session = new Session(cookieId);
+    await expect(Context.storeSession(session)).resolves.toEqual(true);
+    Cookies.prototype.get.mockImplementation(() => cookieId);
+
+    const jwtSession = new Session(jwtPayload.sid);
+    jwtSession.expires = new Date(jwtPayload.exp * 1000);
+    await expect(loadCurrentSession(req, res)).resolves.toEqual(jwtSession);
+    await expect(Context.loadSession(cookieId)).resolves.toBeNull();
+  });
+
+  it("loads nothing if no authorization header is present", async () => {
+    Context.IS_EMBEDDED_APP = true;
+    Context.initialize(Context);
+
+    const req = { headers: {} } as http.IncomingMessage;
+    const res = {} as http.ServerResponse;
+
+    await expect(loadCurrentSession(req, res)).resolves.toBeNull();
+  });
+
+  it("loads nothing if there is no session for embedded apps", async () => {
+    Context.IS_EMBEDDED_APP = true;
+    Context.initialize(Context);
+
+    const token = jwt.sign(jwtPayload, Context.API_SECRET_KEY, { algorithm: 'HS256' });
+    const req = {
+      headers: {
+        "authorization": `Bearer ${token}`,
+      }
+    } as http.IncomingMessage;
+    const res = {} as http.ServerResponse;
+
+    await expect(loadCurrentSession(req, res)).resolves.toBeNull();
+  });
+
+  it("fails if authorization header is not a Bearer token", async () => {
+    Context.IS_EMBEDDED_APP = true;
+    Context.initialize(Context);
+
+    const req = {
+      headers: {
+        'authorization': 'Not a Bearer token!',
+      }
+    } as http.IncomingMessage;
+    const res = {} as http.ServerResponse;
+
+    await expect(loadCurrentSession(req, res)).rejects.toThrow(ShopifyErrors.MissingJwtTokenError);
+  });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Embedded apps will expect to get the current session from the session (assuming JWT) token given in the `Authorization` header, so the `loadCurrentSession` method should allow that as well.

### WHAT is this pull request doing?

It adds support to load a session from a JWT token. If the `sid` value in the payload doesn't match any sessions, but there is currently an OAuth cookie session ongoing, it transfers the contents of the session to ensure we propagate the access token from OAuth into the session.