### PR TITLE
Fix ShopifyOAuth class typo to make correct online access token request.

### DIFF
--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -44,7 +44,7 @@ const ShopifyOAuth = {
       scope: Context.SCOPES,
       redirect_uri: redirect,
       state: state,
-      'grant_options[]': isOnline ? 'per_user' : '',
+      'grant_options[]': isOnline ? 'per-user' : '',
     };
 
     const queryString = querystring.stringify(query);

--- a/src/auth/oauth/test/oauth.test.ts
+++ b/src/auth/oauth/test/oauth.test.ts
@@ -121,7 +121,7 @@ describe('beginAuth', () => {
       scope: Context.SCOPES,
       redirect_uri: Context.HOST_NAME + '/some-callback',
       state: session ? session.state : '',
-      'grant_options[]': 'per_user',
+      'grant_options[]': 'per-user',
     };
     const expectedQueryString = querystring.stringify(query);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,22 +28,13 @@
       "es2018",
       "esnext.asynciterable"
     ],
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
+    "typeRoots": ["./node_modules/@types"],
     "outDir": "./dist",
     "baseUrl": ".",
     "rootDir": "."
   },
-  "include": [
-    "./src/**/*.ts",
-    "./src/**/*.tsx",
-    "./package.json"
-  ],
-  "exclude": [
-    "**/*.test.ts",
-    "**/*.test.tsx"
-  ],
+  "include": ["./src/**/*.ts", "./src/**/*.tsx", "./package.json"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "typedocOptions": {
     "inputFiles": ["./src"],
     "mode": "file",


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Error in `ShopifyOAuth` prevented correctly requesting online access tokens. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Fixes `beginAuth` method. Typo: `per-user` not `per_user` 😅 

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added/updated tests for this change
