### PR TITLE
Don't use the version from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@shopify/shopify-api",
   "version": "0.0.1",
   "description": "Shopify TypeScript API to support core API functionality (auth, graphql proxy, webhooks)",
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "jest",
     "build": "tsc",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,1 @@
-import { version } from '../package.json';
-
-export const SHOPIFY_APP_DEV_KIT_VERSION = version;
+export const SHOPIFY_APP_DEV_KIT_VERSION = '0.0.1';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,9 +31,9 @@
     "typeRoots": ["./node_modules/@types"],
     "outDir": "./dist",
     "baseUrl": ".",
-    "rootDir": "."
+    "rootDir": "src"
   },
-  "include": ["./src/**/*.ts", "./src/**/*.tsx", "./package.json"],
+  "include": ["./src/**/*.ts", "./src/**/*.tsx"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx"],
   "typedocOptions": {
     "inputFiles": ["./src"],


### PR DESCRIPTION
### WHY are these changes introduced?

We initially set up the repo to pull the version from package.json, but that has the unfortunate side effect of requiring that the `dist` folder contains a sub-folder called `src`, which makes importing the library messy as apps would need to add the `src` part to their import commands.

### WHAT is this pull request doing?

Coping with reality and just setting the version independently in the two places where we need it (package.json and version.ts). When we add releasing instructions, we'll simply have to make updating both versions one of the steps, which isn't a big deal in the end, and the resulting build structure is well worth the effort.
