### PR TITLE
Rename Webhooks class into WebhooksRegistry

### DIFF
--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -1,7 +1,7 @@
-import { Webhooks } from './webhooks';
+import { WebhooksRegistry } from './registry';
 
 const ShopifyWebhooks = {
-  Registry: Webhooks,
+  Registry: WebhooksRegistry,
 };
 
 export default ShopifyWebhooks;

--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -45,7 +45,7 @@ export type ProcessReturn = {
   headers: Record<string, string>
 }
 
-interface WebhooksInterface {
+interface RegistryInterface {
   webhookRegistry: WebhookRegistryEntry[],
 
   /**
@@ -121,7 +121,7 @@ function buildQuery(
   `;
 }
 
-const Webhooks: WebhooksInterface = {
+const WebhooksRegistry: RegistryInterface = {
   webhookRegistry: [],
 
   async register({
@@ -179,4 +179,4 @@ const Webhooks: WebhooksInterface = {
   }
 };
 
-export { Webhooks, WebhooksInterface };
+export { WebhooksRegistry, RegistryInterface };

--- a/src/webhooks/test/registry.test.ts
+++ b/src/webhooks/test/registry.test.ts
@@ -1,7 +1,7 @@
 import { Method, Header, StatusCode } from '@shopify/network';
 import '../../test/test_helper';
 import { ApiVersion, ShopifyHeader } from "../../types";
-import { DeliveryMethod, ProcessReturn, RegisterOptions } from '../webhooks';
+import { DeliveryMethod, ProcessReturn, RegisterOptions } from '../registry';
 import ShopifyWebhooks from '..';
 import { createHmac } from 'crypto';
 import { Context } from '../../context';


### PR DESCRIPTION
### WHY are these changes introduced?

While improving the indexes and entry points into the library, we noticed that the name of the webhooks registry would work better if it were explicitly named as Registry rather than just Webhooks.

### WHAT is this pull request doing?

Simply renaming the class and adjusting the file name accordingly.