### PR TITLE
Export submodules as part of Shopify object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,16 @@
 import { Context } from './context';
 import * as ShopifyErrors from './error';
+import ShopifyAuth from './auth';
+import ShopifyClients from './clients';
+import ShopifyUtils from './utils';
+import ShopifyWebhooks from './webhooks';
 
 const Shopify = {
   Context: Context,
+  Auth: ShopifyAuth,
+  Clients: ShopifyClients,
+  Utils: ShopifyUtils,
+  Webhooks: ShopifyWebhooks,
   Errors: ShopifyErrors,
 };
 


### PR DESCRIPTION
### WHY are these changes introduced?

We rearranged the exports as part of #37, but we need to go one step further and include the submodules in the main export as well, otherwise apps can't import the others without having the `dist` part in their import calls.

### WHAT is this pull request doing?

Grabbing the exports from `index.ts` for the submodules and adding them to the base `Shopify` object. The revised usage looks like this:


```typescript
import Shopify, { ApiVersion } from '@shopify/shopify-api';
```

```typescript
Shopify.Context.initialize({ ... });

catch (e) {
  if (e instanceof Shopify.Errors.ShopifyError) { ... }
}

const session = await Shopify.Utils.loadCurrentSession(req, res);

const redirectUrl = await Shopify.Auth.OAuth.beginAuth( ... );

Shopify.Webhooks.Registry.register({ ... });

const client = new Shopify.Clients.Rest.RestClient(session.shop, session.accessToken);

Shopify.Context.initialize({
  API_VERSION: ApiVersion.October20,
  ...
});
```