### PR TITLE
Convert Context.SCOPES array to string when authorizing

### DIFF
--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -44,7 +44,7 @@ const ShopifyOAuth = {
 
     const query = {
       client_id: Context.API_KEY,
-      scope: Context.SCOPES,
+      scope: Context.SCOPES.join(', '),
       redirect_uri: redirect,
       state: state,
       'grant_options[]': isOnline ? 'per-user' : '',


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

When authorizing, only the first scope in the `Context.SCOPES` array was being used.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Convert `Context.SCOPES` array contents to single string when authorizing so all scopes are used.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->