### PR TITLE
Stop expecting protocol in Context.HOST_NAME

### DIFF
--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -16,7 +16,7 @@ const ShopifyOAuth = {
     request: http.IncomingMessage,
     response: http.ServerResponse,
     shop: string,
-    redirect: string,
+    redirectPath: string,
     isOnline = false
   ): Promise<string> {
     Context.throwIfUnitialized();
@@ -45,7 +45,7 @@ const ShopifyOAuth = {
     const query = {
       client_id: Context.API_KEY,
       scope: Context.SCOPES.join(', '),
-      redirect_uri: redirect,
+      redirect_uri: `https://${Context.HOST_NAME}${redirectPath}`,
       state: state,
       'grant_options[]': isOnline ? 'per-user' : '',
     };
@@ -107,7 +107,6 @@ const ShopifyOAuth = {
 
       cookies.set(ShopifyOAuth.SESSION_COOKIE_NAME, currentSession.id, {
         signed: true,
-        domain: Context.HOST_NAME,
         expires: sessionExpiration,
         sameSite: 'none',
         secure: true,


### PR DESCRIPTION
### WHY are these changes introduced?

The OAuth and Webhooks components are currently expecting `Context.HOST_NAME` to be in different formats (OAuth assumes the `https` part will be present, whereas Webhooks don't). This PR aims to sort that out by no longer allowing the protocol to be present.

### WHAT is this pull request doing?

Updating the OAuth to undo my previous suggestion that it should take in the `https` part of the redirect URL - in fact, we will now start expecting a relative path and append the protocol and HOST_NAME ourselves.