### PR TITLE
Properly handle lower case headers on webhook processing

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -31,6 +31,8 @@ class HttpThrottlingError extends HttpRetriableError {
 class InvalidOAuthError extends ShopifyError {}
 class SessionNotFound extends ShopifyError {}
 
+class InvalidWebhookError extends ShopifyError {}
+
 export {
   ShopifyError,
   InvalidHmacError,
@@ -47,4 +49,5 @@ export {
   UninitializedContextError,
   InvalidOAuthError,
   SessionNotFound,
+  InvalidWebhookError,
 };


### PR DESCRIPTION
### WHY are these changes introduced?

Some JS web frameworks use lowercase header names, which was breaking the webhook processing method that expected to find the 'properly' formatted names.

### WHAT is this pull request doing?

Making the header comparison case-insensitive when fetching the headers for webhook processing, by converting both sides of the comparison to lower case before checking.