### PR TITLE
Create JWT session after OAuth

### DIFF
--- a/src/auth/session/session.ts
+++ b/src/auth/session/session.ts
@@ -14,7 +14,7 @@ class Session {
 
   constructor(readonly id: string) {}
 
-  public static async cloneSession(session: Session, newId: string): Promise<Session> {
+  public static cloneSession(session: Session, newId: string): Session {
     const newSession = new Session(newId);
 
     newSession.shop = session.shop;

--- a/src/utils/load-current-session.ts
+++ b/src/utils/load-current-session.ts
@@ -1,5 +1,5 @@
 import http from 'http';
-import Cookies from 'cookies';
+
 import { Context } from '../context';
 import * as ShopifyErrors from '../error';
 import { ShopifyOAuth } from '../auth/oauth/oauth';
@@ -7,32 +7,20 @@ import { Session } from '../auth/session';
 import decodeSessionToken from './decode-session-token';
 
 /**
- * Loads the current user's session, based on the given request.
+ * Loads the current user's session, based on the given request and response.
  *
  * @param req Current HTTP request
  * @param res Current HTTP response
- * @param isOauthCall Whether to expect an ongoing OAuth flow. If there is one and a session token is given,
- *                    the session will be converted for future uses. Generally not necessary if using default OAuth
  */
 export default async function loadCurrentSession(
   request: http.IncomingMessage,
-  response: http.ServerResponse,
-  isOauthCall = false
+  response: http.ServerResponse
 ): Promise<Session | null> {
   Context.throwIfUninitialized();
 
-  const cookies = new Cookies(request, response, {
-    secure: true,
-    keys: [Context.API_SECRET_KEY],
-  });
-  const sessionCookie: string | undefined = cookies.get(
-    ShopifyOAuth.SESSION_COOKIE_NAME,
-    { signed: true }
-  );
-
   let session: Session | null = null;
 
-  if (!isOauthCall && Context.IS_EMBEDDED_APP) {
+  if (Context.IS_EMBEDDED_APP) {
     const authHeader = request.headers['authorization'];
     if (authHeader) {
       const matches = authHeader.match(/^Bearer (.+)$/);
@@ -41,22 +29,12 @@ export default async function loadCurrentSession(
       }
 
       const jwtPayload = decodeSessionToken(matches[1]);
-      session = await Context.loadSession(jwtPayload.sid);
-
-      // JWT session does not exist. If there is an OAuth session, transfer it to a new JWT one
-      if (!session && sessionCookie) {
-        const oauthSession = await Context.loadSession(sessionCookie);
-        if (oauthSession) {
-          session = await Session.cloneSession(oauthSession, jwtPayload.sid);
-          session.expires = new Date(jwtPayload.exp * 1000);
-
-          await Context.storeSession(session);
-          await Context.deleteSession(oauthSession.id);
-        }
-      }
+      const jwtSessionId = ShopifyOAuth.getJwtSessionId(jwtPayload.dest.replace(/^https:\/\//, ''), jwtPayload.sub);
+      session = await Context.loadSession(jwtSessionId);
     }
   }
   else {
+    const sessionCookie = ShopifyOAuth.getCookieSessionId(request, response);
     if (sessionCookie) {
       session = await Context.loadSession(sessionCookie);
     }


### PR DESCRIPTION
### WHY are these changes introduced?

For embedded apps, we won't be able to load cookies from the iframe once the OAuth process is completed, especially in Safari which is much stricter about blocking 3rd party cookies. To work around that, we needed a way to map the OAuth completion request (after we get the access token) to the JWT session (created by App Bridge after the embedded app loads), that didn't require on the browser sending us the session cookie we used for OAuth.

### WHAT is this pull request doing?

After we get the (online) access token, we extract the sub + shop and use that pair to create a new session in our storage, whose id can be recreated from JWT sessions, allowing us to map those sessions in the backend without any need for 3rd party cookies.