### PR TITLE
Adds deleteCurrentSession function

### DIFF
--- a/src/utils/delete-current-session.ts
+++ b/src/utils/delete-current-session.ts
@@ -6,7 +6,7 @@ import { ShopifyOAuth } from '../auth/oauth/oauth';
 import decodeSessionToken from './decode-session-token';
 
 /**
- * Finds and deletes the current user's session, based on the give request and response
+ * Finds and deletes the current user's session, based on the given request and response
  *
  * @param req Current HTTP request
  * @param res Current HTTP response
@@ -16,13 +16,6 @@ export default async function deleteCurrentSession(
   res: http.ServerResponse
 ): Promise<boolean | never> {
   Context.throwIfUninitialized();
-
-  const cookies = new Cookies(req, res, {
-    secure: true,
-    keys: [Context.API_SECRET_KEY],
-  });
-
-  const sessionCookie: string | undefined = cookies.get(ShopifyOAuth.SESSION_COOKIE_NAME, { signed: true });
 
   if (Context.IS_EMBEDDED_APP) {
     const authHeader = req.headers['authorization'];
@@ -40,6 +33,13 @@ export default async function deleteCurrentSession(
       throw new ShopifyErrors.MissingJwtTokenError('Missing authorization header');
     }
   } else {
+    const cookies = new Cookies(req, res, {
+      secure: true,
+      keys: [Context.API_SECRET_KEY],
+    });
+
+    const sessionCookie: string | undefined = cookies.get(ShopifyOAuth.SESSION_COOKIE_NAME, { signed: true });
+
     if (sessionCookie) {
       await Context.deleteSession(sessionCookie);
       cookies.set(ShopifyOAuth.SESSION_COOKIE_NAME);

--- a/src/utils/test/delete-current-session.test.ts
+++ b/src/utils/test/delete-current-session.test.ts
@@ -17,8 +17,8 @@ describe('deleteCurrenSession', () => {
   let jwtPayload: JwtPayload;
   beforeEach(() => {
     jwtPayload = {
-      iss: 'test-shop.myshopify.io/admin',
-      dest: 'test-shop.myshopify.io',
+      iss: 'https://test-shop.myshopify.io/admin',
+      dest: 'https://test-shop.myshopify.io',
       aud: Context.API_KEY,
       sub: '1',
       exp: Date.now() / 1000 + 3600,
@@ -30,8 +30,8 @@ describe('deleteCurrenSession', () => {
   });
 
   it('finds and deletes the current session when using cookies', async () => {
-    Context.initialize(Context);
     Context.IS_EMBEDDED_APP = false;
+    Context.initialize(Context);
 
     const req = {} as http.IncomingMessage;
     const res = {} as http.ServerResponse;
@@ -48,8 +48,8 @@ describe('deleteCurrenSession', () => {
   });
 
   it('finds and deletes the current session when using JWT', async () => {
-    Context.initialize(Context);
     Context.IS_EMBEDDED_APP = true;
+    Context.initialize(Context);
 
     const token = jwt.sign(jwtPayload, Context.API_SECRET_KEY, { algorithm: 'HS256' });
     const req = {
@@ -67,8 +67,8 @@ describe('deleteCurrenSession', () => {
   });
 
   it('throws an error when no cookie is found', async () => {
-    Context.initialize(Context);
     Context.IS_EMBEDDED_APP = false;
+    Context.initialize(Context);
 
     const req = {} as http.IncomingMessage;
     const res = {} as http.ServerResponse;
@@ -79,8 +79,8 @@ describe('deleteCurrenSession', () => {
   });
 
   it('throws an error when authorization header is missing or not a bearer token', async () => {
-    Context.initialize(Context);
     Context.IS_EMBEDDED_APP = true;
+    Context.initialize(Context);
 
     let req = {
       headers: {},


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

We have `deleteSession` but this requires first grabbing the session you want to delete to pass to that function. This essentially wraps that and does both: regardless of session type (JWT or Cookie) it will find the current session based on the current `request` and delete it from session storage for you. 

### WHAT is this pull request doing?

Adds the `deleteCurrentSession` method and testing. This method follows a similar pattern to `loadCurrentSession`. 

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

