### PR TITLE
Add section on sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,33 @@ First of all, in your `src/index.ts` file, you'll need to set up your applicatio
 - In your browser, navigate to `{your ngrok address}/oauth/begin` to begin OAuth
 - When OAuth completes, navigate to your REST and GraphQL endpoints to see the requested data being returned
 
+## Notes on session handling
+
+Before you start writing your application, please note that the Shopify library stores some information for OAuth in sessions. Since each application may choose a different strategy to store information, the library cannot dictate any specific storage strategy. By default, `Shopify.Context` is initialized with `MemorySessionStorage`, which will enable you to start developing your app by storing sessions in memory. You can continue to follow this guide to quickly get your app set up, but please keep the following in mind.
+
+`MemorySessionStorage` is **purposely** designed to be a single-process, development-only solution. It **will leak** memory in most cases and delete all sessions when your app restarts. You should **never** use it in production apps. In order to use your preferred storage choice with the Shopify library, you'll need to perform a few steps:
+
+- Create a class that extends the `SessionStorage` interface, and implements the following methods: `loadSession`, `storeSession`, and `deleteSession`.
+- _OR_ Create a new instance of `CustomSessionStorage`, providing callbacks for these methods.
+- Implement those methods so that they perform the necessary actions in your app's storage.
+- Provide an instance of that class when calling `Shopify.Context.initialize`, for example:
+```ts
+  // src/my_session_storage.ts
+  import { SessionStorage, Session } from '@shopify/shopify-api';
+
+  class MySessionStorage extends SessionStorage {
+    public async loadSession(sessionId: string) { ... }
+    public async storeSession(session: Session) { ... }
+    public async deleteSession(sessionId: string) { ... }
+  }
+
+  // src/index.ts
+  Shopify.Context.initialize({
+    ... // app settings
+    SESSION_STORAGE: new MySessionStorage(),
+  });
+```
+
 ## Add a route to start OAuth
 
 The route for starting the OAuth process (in this case `/login`) will use the library's `beginAuth` method.  The `beginAuth` method takes in the request and response objects (from the `http` module), along with the target shop _(string)_, redirect route _(string)_, and whether or not you are requesting [online access](https://shopify.dev/concepts/about-apis/authentication#api-access-modes) _(boolean)_.  The method will return a URI that will be used for redirecting the user to the Shopify Authentication screen.


### PR DESCRIPTION
### WHY are these changes introduced?

The default session storage provided by the library is not meant for production use, and therefore we need to be certain to remind developers that they need to provide a production-worthy implementation of `SessionStorage` before they can launch their app.

### WHAT is this pull request doing?

Adding - in (hopefully) fairly strongly worded language - information around session management, and what is expected from the developer.