### PR TITLE
Change Session loading to return undefined when there is no Session

### DIFF
--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -89,7 +89,7 @@ const ShopifyOAuth = {
       secure: true,
     });
 
-    let currentSession: Session | null = null;
+    let currentSession: Session | undefined = undefined;
 
     const sessionCookie = this.getCookieSessionId(request, response);
     if (sessionCookie) {
@@ -124,9 +124,7 @@ const ShopifyOAuth = {
     if (currentSession.isOnline) {
       const responseBody = postResponse.body as OnlineAccessResponse;
       const { access_token, scope, ...rest } = responseBody;
-      const sessionExpiration = new Date(
-        Date.now() + responseBody.expires_in * 1000
-      );
+      const sessionExpiration = new Date(Date.now() + responseBody.expires_in * 1000);
       currentSession.accessToken = access_token;
       currentSession.expires = sessionExpiration;
       currentSession.scope = scope;
@@ -140,7 +138,7 @@ const ShopifyOAuth = {
     // If app is embedded or this is an offline session, we're no longer intereseted in the cookie
     cookies.set(ShopifyOAuth.SESSION_COOKIE_NAME, currentSession.id, {
       signed: true,
-      expires: (Context.IS_EMBEDDED_APP || !currentSession.isOnline) ? new Date() : currentSession.expires,
+      expires: Context.IS_EMBEDDED_APP || !currentSession.isOnline ? new Date() : currentSession.expires,
       sameSite: 'none',
       secure: true,
     });
@@ -148,12 +146,11 @@ const ShopifyOAuth = {
     // If this is an online session for an embedded app, we assume it will be loaded from a JWT from here on out
     if (Context.IS_EMBEDDED_APP && currentSession.isOnline) {
       const onlineInfo = currentSession.onlineAccesInfo as OnlineAccessInfo;
-      const jwtSessionId = this.getJwtSessionId(currentSession.shop, ""+onlineInfo.associated_user.id);
+      const jwtSessionId = this.getJwtSessionId(currentSession.shop, '' + onlineInfo.associated_user.id);
       const jwtSession = Session.cloneSession(currentSession, jwtSessionId);
       await Context.deleteSession(currentSession.id);
       await Context.storeSession(jwtSession);
-    }
-    else {
+    } else {
       await Context.storeSession(currentSession);
     }
   },

--- a/src/auth/oauth/test/oauth.test.ts
+++ b/src/auth/oauth/test/oauth.test.ts
@@ -37,20 +37,18 @@ describe('beginAuth', () => {
     req = {} as http.IncomingMessage;
     res = {} as http.ServerResponse;
 
-    Cookies.prototype.set.mockImplementation(
-      (cookieName: string, cookieValue: string) => {
-        expect(cookieName).toBe('shopify_app_session');
-        cookies.id = cookieValue;
-      }
-    );
+    Cookies.prototype.set.mockImplementation((cookieName: string, cookieValue: string) => {
+      expect(cookieName).toBe('shopify_app_session');
+      cookies.id = cookieValue;
+    });
   });
 
   test('throws Context error when not properly initialized', async () => {
     Context.API_KEY = '';
 
-    await expect(() =>
-      ShopifyOAuth.beginAuth(req, res, shop, '/some-callback')
-    ).rejects.toBeInstanceOf(ShopifyErrors.UninitializedContextError);
+    await expect(() => ShopifyOAuth.beginAuth(req, res, shop, '/some-callback')).rejects.toBeInstanceOf(
+      ShopifyErrors.UninitializedContextError
+    );
   });
 
   test('creates and stores a new session for the specified shop', async () => {
@@ -121,12 +119,10 @@ describe('validateAuthCallback', () => {
     req = {} as http.IncomingMessage;
     res = {} as http.ServerResponse;
 
-    Cookies.prototype.set.mockImplementation(
-      (cookieName: string, cookieValue: string) => {
-        expect(cookieName).toBe('shopify_app_session');
-        cookies.id = cookieValue;
-      }
-    );
+    Cookies.prototype.set.mockImplementation((cookieName: string, cookieValue: string) => {
+      expect(cookieName).toBe('shopify_app_session');
+      cookies.id = cookieValue;
+    });
 
     Cookies.prototype.get.mockImplementation(() => cookies.id);
   });
@@ -143,9 +139,9 @@ describe('validateAuthCallback', () => {
     const expectedHmac = generateLocalHmac(testCallbackQuery);
     testCallbackQuery.hmac = expectedHmac;
 
-    await expect(() =>
-      ShopifyOAuth.validateAuthCallback(req, res, testCallbackQuery)
-    ).rejects.toBeInstanceOf(ShopifyErrors.UninitializedContextError);
+    await expect(() => ShopifyOAuth.validateAuthCallback(req, res, testCallbackQuery)).rejects.toBeInstanceOf(
+      ShopifyErrors.UninitializedContextError
+    );
   });
 
   test("throws an error when receiving a callback for a shop that doesn't have a session cookie", async () => {
@@ -178,9 +174,9 @@ describe('validateAuthCallback', () => {
     };
     testCallbackQuery.hmac = 'definitely the wrong hmac';
 
-    await expect(() =>
-      ShopifyOAuth.validateAuthCallback(req, res, testCallbackQuery)
-    ).rejects.toBeInstanceOf(ShopifyErrors.InvalidOAuthError);
+    await expect(() => ShopifyOAuth.validateAuthCallback(req, res, testCallbackQuery)).rejects.toBeInstanceOf(
+      ShopifyErrors.InvalidOAuthError
+    );
   });
 
   test('requests access token for valid callbacks with offline access and updates session', async () => {
@@ -204,9 +200,7 @@ describe('validateAuthCallback', () => {
     await ShopifyOAuth.validateAuthCallback(req, res, testCallbackQuery);
     session = await Context.loadSession(cookies.id);
 
-    session
-      ? expect(session.accessToken).toBe(successResponse.access_token)
-      : false;
+    session ? expect(session.accessToken).toBe(successResponse.access_token) : false;
   });
 
   test('requests access token for valid callbacks with online access and updates session with expiration and onlineAccessInfo', async () => {
@@ -255,7 +249,7 @@ describe('validateAuthCallback', () => {
     }
   });
 
-  test("converts an OAuth session into a JWT one if is online", async () => {
+  test('converts an OAuth session into a JWT one if is online', async () => {
     Context.IS_EMBEDDED_APP = true;
     Context.initialize(Context);
 
@@ -290,30 +284,30 @@ describe('validateAuthCallback', () => {
     fetchMock.mockResponse(JSON.stringify(successResponse));
     await ShopifyOAuth.validateAuthCallback(req, res, testCallbackQuery);
 
-    await expect(Context.loadSession(cookies.id)).resolves.toBeNull();
+    await expect(Context.loadSession(cookies.id)).resolves.toBeUndefined();
 
     const jwtPayload: JwtPayload = {
       iss: `https://${shop}/admin`,
       dest: `https://${shop}`,
       aud: Context.API_KEY,
-      sub: "1",
+      sub: '1',
       exp: Date.now() / 1000 + 3600,
       nbf: 1234,
       iat: 1234,
-      jti: "4321",
-      sid: "abc123",
+      jti: '4321',
+      sid: 'abc123',
     };
 
     const jwtSessionId = `${shop}_${jwtPayload.sub}`;
-    await expect(Context.loadSession(jwtSessionId)).resolves.not.toBeNull();
+    await expect(Context.loadSession(jwtSessionId)).resolves.not.toBeUndefined();
 
     // Simulate a subsequent JWT request to see if the session is loaded as the current one
 
     const token = jwt.sign(jwtPayload, Context.API_SECRET_KEY, { algorithm: 'HS256' });
     const jwtReq = {
       headers: {
-        "authorization": `Bearer ${token}`,
-      }
+        authorization: `Bearer ${token}`,
+      },
     } as http.IncomingMessage;
     const jwtRes = {} as http.ServerResponse;
 

--- a/src/auth/session/session_storage.ts
+++ b/src/auth/session/session_storage.ts
@@ -16,7 +16,7 @@ interface SessionStorage {
    *
    * @param id Id of the session to load
    */
-  loadSession(id: string): Promise<Session | null>;
+  loadSession(id: string): Promise<Session | undefined>;
 
   /**
    * Deletes a session from storage.

--- a/src/auth/session/storage/custom.ts
+++ b/src/auth/session/storage/custom.ts
@@ -4,8 +4,8 @@ import { SessionStorage } from '../session_storage';
 export class CustomSessionStorage implements SessionStorage {
   constructor(
     readonly storeCallback: (session: Session) => boolean,
-    readonly loadCallback: (id: string) => Session | null,
-    readonly deleteCallback: (id: string) => boolean,
+    readonly loadCallback: (id: string) => Session | undefined,
+    readonly deleteCallback: (id: string) => boolean
   ) {
     this.storeCallback = storeCallback;
     this.loadCallback = loadCallback;
@@ -16,7 +16,7 @@ export class CustomSessionStorage implements SessionStorage {
     return this.storeCallback(session);
   }
 
-  public async loadSession(id: string): Promise<Session | null> {
+  public async loadSession(id: string): Promise<Session | undefined> {
     return this.loadCallback(id);
   }
 

--- a/src/auth/session/storage/memory.ts
+++ b/src/auth/session/storage/memory.ts
@@ -2,15 +2,15 @@ import { Session } from '../session';
 import { SessionStorage } from '../session_storage';
 
 export class MemorySessionStorage implements SessionStorage {
-  private sessions: {[id: string]: Session} = {};
+  private sessions: { [id: string]: Session } = {};
 
   public async storeSession(session: Session): Promise<boolean> {
     this.sessions[session.id] = session;
     return true;
   }
 
-  public async loadSession(id: string): Promise<Session | null> {
-    return this.sessions[id] || null;
+  public async loadSession(id: string): Promise<Session | undefined> {
+    return this.sessions[id] || undefined;
   }
 
   public async deleteSession(id: string): Promise<boolean> {

--- a/src/auth/session/test/custom.test.ts
+++ b/src/auth/session/test/custom.test.ts
@@ -55,12 +55,12 @@ test('custom session storage failures and exceptions are raised', async () => {
 
   let storage = new CustomSessionStorage(
     () => false,
-    () => null,
+    () => undefined,
     () => false
   );
 
   await expect(storage.storeSession(session)).resolves.toBe(false);
-  await expect(storage.loadSession(sessionId)).resolves.toBeNull();
+  await expect(storage.loadSession(sessionId)).resolves.toBeUndefined();
   await expect(storage.deleteSession(sessionId)).resolves.toBe(false);
 
   storage = new CustomSessionStorage(
@@ -75,13 +75,7 @@ test('custom session storage failures and exceptions are raised', async () => {
     }
   );
 
-  await expect(storage.storeSession(session)).rejects.toEqual(
-    'Failed to store!'
-  );
-  await expect(storage.loadSession(sessionId)).rejects.toEqual(
-    'Failed to load!'
-  );
-  await expect(storage.deleteSession(sessionId)).rejects.toEqual(
-    'Failed to delete!'
-  );
+  await expect(storage.storeSession(session)).rejects.toEqual('Failed to store!');
+  await expect(storage.loadSession(sessionId)).rejects.toEqual('Failed to load!');
+  await expect(storage.deleteSession(sessionId)).rejects.toEqual('Failed to delete!');
 });

--- a/src/auth/session/test/memory.test.ts
+++ b/src/auth/session/test/memory.test.ts
@@ -15,7 +15,7 @@ test('can store and delete sessions in memory', async () => {
   await expect(storage.loadSession(sessionId)).resolves.toEqual(session);
 
   await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
-  await expect(storage.loadSession(sessionId)).resolves.toBeNull();
+  await expect(storage.loadSession(sessionId)).resolves.toBeUndefined();
 
   // Deleting a non-existing session should work
   await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
@@ -23,5 +23,5 @@ test('can store and delete sessions in memory', async () => {
 
 test('wrong ids return null sessions from memory', async () => {
   const storage = new MemorySessionStorage();
-  await expect(storage.loadSession('not_a_session_id')).resolves.toBeNull();
+  await expect(storage.loadSession('not_a_session_id')).resolves.toBeUndefined();
 });

--- a/src/context.ts
+++ b/src/context.ts
@@ -24,7 +24,7 @@ interface ContextInterface extends ContextParams {
    *
    * @param id Id of the session to load
    */
-  loadSession(id: string): Promise<Session | null>;
+  loadSession(id: string): Promise<Session | undefined>;
 
   /**
    * Deletes a session using the assigned strategy.
@@ -86,7 +86,7 @@ const Context: ContextInterface = {
     return this.SESSION_STORAGE.storeSession(session);
   },
 
-  async loadSession(id: string): Promise<Session | null> {
+  async loadSession(id: string): Promise<Session | undefined> {
     return this.SESSION_STORAGE.loadSession(id);
   },
 

--- a/src/utils/test/delete-current-session.test.ts
+++ b/src/utils/test/delete-current-session.test.ts
@@ -44,7 +44,7 @@ describe('deleteCurrenSession', () => {
     Cookies.prototype.get.mockImplementation(() => cookieId);
 
     await expect(deleteCurrentSession(req, res)).resolves.toBe(true);
-    await expect(loadCurrentSession(req, res)).resolves.toBe(null);
+    await expect(loadCurrentSession(req, res)).resolves.toBe(undefined);
   });
 
   it('finds and deletes the current session when using JWT', async () => {
@@ -63,7 +63,7 @@ describe('deleteCurrenSession', () => {
     await expect(Context.storeSession(session)).resolves.toEqual(true);
 
     await expect(deleteCurrentSession(req, res)).resolves.toBe(true);
-    await expect(loadCurrentSession(req, res)).resolves.toBe(null);
+    await expect(loadCurrentSession(req, res)).resolves.toBe(undefined);
   });
 
   it('throws an error when no cookie is found', async () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

We were previously returning `null` when no `Session` is found. We should instead return `undefined` 

### WHAT is this pull request doing?

Updates all `Session` loading implementation return types to `Session | undefined` 

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

