### PR TITLE
Add utils to load and delete offline sessions

### DIFF
--- a/src/utils/delete-offline-session.ts
+++ b/src/utils/delete-offline-session.ts
@@ -1,0 +1,15 @@
+import { Context } from '../context';
+import OAuth from '../../src/auth/oauth';
+
+/**
+ * Helper method to find and delete offline sessions by shop url.
+ *
+ * @param shop the shop url to find and delete a session for
+ */
+export default async function deleteOfflineSession(shop: string): Promise<boolean> {
+  Context.throwIfUninitialized();
+
+  const sessionId = OAuth.getOfflineSessionId(shop);
+
+  return Context.deleteSession(sessionId);
+}

--- a/src/utils/load-offline-session.ts
+++ b/src/utils/load-offline-session.ts
@@ -1,0 +1,26 @@
+import { Session } from '../auth/session/session';
+import { Context } from '../context';
+import OAuth from '../../src/auth/oauth';
+
+/**
+ * Helper method for quickly loading offline sessions by shop url.
+ * By default, returns undefined if there is no session, or the session found is expired.
+ * Optionally, pass a second argument for 'includeExpired' set to true to return expired sessions.
+ *
+ * @param shop the shop url to find the offline session for
+ * @param includeExpired optionally include expired sessions, defaults to false
+ */
+export default async function loadOfflineSession(shop: string, includeExpired = false): Promise<Session | undefined> {
+  Context.throwIfUninitialized();
+
+  const sessionId = OAuth.getOfflineSessionId(shop);
+  const session = await Context.loadSession(sessionId);
+
+  const now = new Date();
+
+  if (session && !includeExpired && session.expires && session.expires.getTime() < now.getTime()) {
+    return undefined;
+  }
+
+  return session;
+}

--- a/src/utils/test/delete-offline-session.test.ts
+++ b/src/utils/test/delete-offline-session.test.ts
@@ -1,0 +1,22 @@
+import '../../test/test_helper';
+
+import deleteOfflineSession from '../delete-offline-session';
+import Session from '../../auth/session/';
+import OAuth from '../../auth/oauth';
+import { Context } from '../../context';
+import loadOfflineSession from '../load-offline-session';
+
+describe('deleteOfflineSession', () => {
+  const shop = 'some-shop.myshopify.com';
+  const offlineId = OAuth.getOfflineSessionId(shop);
+
+  beforeEach(() => {
+    const offlineSession = new Session.Session(offlineId);
+    Context.storeSession(offlineSession);
+  });
+
+  it('deletes offline sessions by shop', async () => {
+    await expect(deleteOfflineSession(shop)).resolves.toBe(true);
+    await expect(loadOfflineSession(shop)).resolves.toBeUndefined();
+  });
+});

--- a/src/utils/test/load-offline-session.test.ts
+++ b/src/utils/test/load-offline-session.test.ts
@@ -1,0 +1,40 @@
+import '../../test/test_helper';
+
+import loadOfflineSession from '../load-offline-session';
+import { Session } from '../../auth/session/session';
+import OAuth from '../../auth/oauth';
+import { Context } from '../../context';
+
+describe('loadOfflineSession', () => {
+  const shop = 'some-shop.myshopify.com';
+
+  it('returns undefined if no session is found', async () => {
+    await expect(loadOfflineSession(shop)).resolves.toBeUndefined();
+  });
+
+  it('loads offline sessions by shop', async () => {
+    const offlineId = OAuth.getOfflineSessionId(shop);
+    const offlineSession = new Session(offlineId);
+    Context.storeSession(offlineSession);
+
+    expect(await loadOfflineSession(shop)).toBe(offlineSession);
+  });
+
+  it('returns undefined for expired sessions by default', async () => {
+    const offlineId = OAuth.getOfflineSessionId(shop);
+    const offlineSession = new Session(offlineId);
+    offlineSession.expires = new Date('2020-01-01');
+    Context.storeSession(offlineSession);
+
+    await expect(loadOfflineSession(shop)).resolves.toBeUndefined();
+  });
+
+  it('returns expired sessions when includeExpired is true', async () => {
+    const offlineId = OAuth.getOfflineSessionId(shop);
+    const offlineSession = new Session(offlineId);
+    offlineSession.expires = new Date('2020-01-01');
+    Context.storeSession(offlineSession);
+
+    await expect(loadOfflineSession(shop, true)).resolves.toBe(offlineSession);
+  });
+});


### PR DESCRIPTION
### WHAT is this pull request doing?

These utils are the `offline` accompaniment to the `loadCurrentSession` and `deleteCurrentSession` utils for `online` sessions. `loadOfflineSession` wraps up the functionality to generate the offline session id, and load the appropriate session;  and then `deleteOfflineSession` does the same for deletion. 