### PR TITLE
Extend cookie OAuth session to allow initial app loads

### DIFF
--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -143,16 +143,18 @@ const ShopifyOAuth = {
       secure: true,
     });
 
-    // If this is an online session for an embedded app, we assume it will be loaded from a JWT from here on out
+    // If this is an online session for an embedded app, we assume it will be loaded from a JWT from here on out. The
+    // cookie session is preserved for 30s so that the app skeleton page can still be loaded using it
     if (Context.IS_EMBEDDED_APP && currentSession.isOnline) {
       const onlineInfo = currentSession.onlineAccesInfo as OnlineAccessInfo;
       const jwtSessionId = this.getJwtSessionId(currentSession.shop, '' + onlineInfo.associated_user.id);
       const jwtSession = Session.cloneSession(currentSession, jwtSessionId);
-      await Context.deleteSession(currentSession.id);
       await Context.storeSession(jwtSession);
-    } else {
-      await Context.storeSession(currentSession);
+
+      currentSession.expires = new Date(Date.now() + 30000);
     }
+
+    await Context.storeSession(currentSession);
   },
 
   /**

--- a/src/utils/load-current-session.ts
+++ b/src/utils/load-current-session.ts
@@ -31,10 +31,12 @@ export default async function loadCurrentSession(
       const jwtPayload = decodeSessionToken(matches[1]);
       const jwtSessionId = ShopifyOAuth.getJwtSessionId(jwtPayload.dest.replace(/^https:\/\//, ''), jwtPayload.sub);
       session = await Context.loadSession(jwtSessionId);
-    } else {
-      throw new ShopifyErrors.MissingJwtTokenError('Missing authorization header');
     }
-  } else {
+  }
+
+  // We fall back to the cookie session to allow apps to load their skeleton page after OAuth, so they can set up App
+  // Bridge and get a new JWT.
+  if (!session) {
     const sessionCookie = ShopifyOAuth.getCookieSessionId(request, response);
     if (sessionCookie) {
       session = await Context.loadSession(sessionCookie);


### PR DESCRIPTION
### WHY are these changes introduced?

While updating `shopify-app-node` to use this library, I ran into an issue where OAuth worked normally, but since we destroyed the cookie session right away, we were unable to run the initial request to the app in a logged in state, so that the frontend can build its App Bridge and get a JWT.

These changes extend the OAuth cookie session by 30 seconds instead of deleting it right away, which allows the app to load itself to cover the above scenario.

### WHAT is this pull request doing?

Extending the cookie session, and changing `loadCurrentSession` to fall back to the cookie version if JWT isn't available yet. Since the cookie session is only extended for a short period of time and there is no support for 3rd party cookies baked into the library, any requests made without a JWT from an embedded app would fail outright due to the OAuth session cookie not being available to the server.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
