### PR TITLE
Clone the JWT session before overriding the expiration

### DIFF
--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -143,14 +143,15 @@ const ShopifyOAuth = {
       oauthSessionExpiration = new Date();
     }
     else if (Context.IS_EMBEDDED_APP) {
-      oauthSessionExpiration = new Date(Date.now() + 30000);
-      currentSession.expires = oauthSessionExpiration;
-
-      // If this is an online session for an embedded app, prepare a JWT session to be used from here on out
+      // If this is an online session for an embedded app, prepare a JWT session to be used going forward
       const onlineInfo = currentSession.onlineAccesInfo as OnlineAccessInfo;
       const jwtSessionId = this.getJwtSessionId(currentSession.shop, '' + onlineInfo.associated_user.id);
       const jwtSession = Session.cloneSession(currentSession, jwtSessionId);
       await Context.storeSession(jwtSession);
+
+      // Make sure the current OAuth session expires along with the cookie
+      oauthSessionExpiration = new Date(Date.now() + 30000);
+      currentSession.expires = oauthSessionExpiration;
     }
 
     cookies.set(ShopifyOAuth.SESSION_COOKIE_NAME, currentSession.id, {


### PR DESCRIPTION
### WHY are these changes introduced?

My previous fix was faulty in that it was overriding the expiration of the OAuth session **before** cloning it, which meant that the JWT session was also expiring right away.

### WHAT is this pull request doing?

Cloning the JWT session prior to overwriting the expiration of the cookie one, so the expiration date is preserved.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
