### PR TITLE
Check if a webhook is registered before calling Shopify

### DIFF
--- a/src/clients/http_client/test/test_helper.ts
+++ b/src/clients/http_client/test/test_helper.ts
@@ -1,24 +1,30 @@
 import fetchMock from 'jest-fetch-mock';
 
+let currentCall = 0;
+beforeEach(() => {
+  currentCall = 0;
+});
+
 export function assertHttpRequest(
   method: string,
   domain: string,
   path: string,
   headers: Record<string, unknown> = {},
   data: string | null = null,
-  retries: number | null = null,
+  tries = 1,
 ): void {
-  const expectResult = expect(fetchMock);
-  expectResult.toBeCalledWith(
-    `https://${domain}${path}`,
-    expect.objectContaining({
-      method,
-      headers: expect.objectContaining(headers),
-      body: data,
-    }),
-  );
-
-  if (retries !== null) {
-    expectResult.toHaveBeenCalledTimes(retries);
+  const maxCall = currentCall + tries;
+  for (let i = currentCall; i < maxCall; i++) {
+    currentCall++;
+    expect(fetchMock.mock.calls[i]).toEqual(
+      [
+        `https://${domain}${path}`,
+        expect.objectContaining({
+          method,
+          headers: expect.objectContaining(headers),
+          body: data,
+        }),
+      ],
+    );
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Our current webhook code runs into issues if we try to register a webhook that is already there, because Shopify won't accept a `webhookSubscriptionCreate` call if there is already a handler in place for that topic. It also doesn't accept `webhookSubscriptionUpdate` calls if the callback URL hasn't changed.

This PR aims to make sure the library works around those restrictions so that apps can simply request to register a webhook and trust it will be there.

### WHAT is this pull request doing?

It defines a few possible execution paths for webhook registration. First of all, we check if there is already a handler for the given topic. Then:

- If the topic has never been registered, we simply register it as before, and add it to the registry's callbacks
- If the topic exists, but its callback URL changed, we update the address on Shopify before adding it to the registry
- If it exists and the URL is the same, we simply skip calling Shopify entirely and add it to the registry

**NOTE**: one unintended side effect of this change is that we're always adding new entries to the registry (as in on every successful OAuth flow). This was masked in the original code by the fact that we never succeeded in subsequent register calls because Shopify would fail. I will patch that up so that we replace the callback in the registry as well if it is there.
**UPDATE**: the above note was properly fixed by the PR.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
