### PR TITLE
Add withSession utility method

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -30,8 +30,12 @@ class HttpThrottlingError extends HttpRetriableError {
 
 class InvalidOAuthError extends ShopifyError {}
 class SessionNotFound extends ShopifyError {}
+class InvalidSession extends ShopifyError {}
 
 class InvalidWebhookError extends ShopifyError {}
+
+class MissingRequiredArgument extends ShopifyError {}
+class UnsupportedClientType extends ShopifyError {}
 
 export {
   ShopifyError,
@@ -49,5 +53,8 @@ export {
   UninitializedContextError,
   InvalidOAuthError,
   SessionNotFound,
+  InvalidSession,
   InvalidWebhookError,
+  MissingRequiredArgument,
+  UnsupportedClientType,
 };

--- a/src/utils/test/with-session.test.ts
+++ b/src/utils/test/with-session.test.ts
@@ -1,0 +1,196 @@
+import '../../test/test_helper';
+
+import http from 'http';
+
+import jwt from 'jsonwebtoken';
+import Cookies from 'cookies';
+
+import {Session} from '../../auth/session';
+import OAuth from '../../auth/oauth';
+import withSession from '../with-session';
+import {Context} from '../../context';
+import {RestWithSession, GraphqlWithSession} from '../types';
+import {RestClient} from '../../clients/rest';
+import {GraphqlClient} from '../../clients/graphql';
+import * as ShopifyErrors from '../../error';
+
+jest.mock('cookies');
+
+describe('withSession', () => {
+  const shop = 'fake-shop.myshopify.io';
+
+  it('throws an error for missing shop when !isOnline', async () => {
+    await expect(withSession({clientType: 'rest', isOnline: false})).rejects.toThrow(
+      ShopifyErrors.MissingRequiredArgument,
+    );
+  });
+
+  it('throws an error for missing request and response objects when isOnline', async () => {
+    await expect(withSession({clientType: 'graphql', isOnline: true})).rejects.toThrow(
+      ShopifyErrors.MissingRequiredArgument,
+    );
+  });
+
+  it('throws an error for unsupported clientTypes', async () => {
+
+    /* we need to set up a session for this test, because errors will be thrown for a missing session before
+    hitting the clientType error */
+
+    const offlineId = OAuth.getOfflineSessionId(shop);
+    const session = new Session(offlineId);
+    session.isOnline = false;
+    session.shop = shop;
+    session.accessToken = 'gimme-access';
+    await Context.storeSession(session);
+
+    await expect(withSession({clientType: 'blah' as any, isOnline: false, shop})).rejects.toThrow(
+      ShopifyErrors.UnsupportedClientType,
+    );
+  });
+
+  it('throws an error when there is no session matching the params requested', async () => {
+    const req = {} as http.IncomingMessage;
+    const res = {} as http.ServerResponse;
+
+    await expect(withSession({clientType: 'rest', isOnline: false, shop})).rejects.toThrow(
+      ShopifyErrors.SessionNotFound,
+    );
+    await expect(withSession({clientType: 'graphql', isOnline: true, req, res})).rejects.toThrowError(
+      ShopifyErrors.SessionNotFound,
+    );
+  });
+
+  it('throws an error when the session is not yet authenticated', async () => {
+    const offlineId = OAuth.getOfflineSessionId(shop);
+    const session = new Session(offlineId);
+    session.isOnline = false;
+    session.shop = shop;
+    await Context.storeSession(session);
+
+    await expect(withSession({clientType: 'rest', isOnline: false, shop})).rejects.toThrow(
+      ShopifyErrors.InvalidSession,
+    );
+  });
+
+  it('returns an object containing the appropriate client and session for offline sessions', async () => {
+    const offlineId = OAuth.getOfflineSessionId(shop);
+    const session = new Session(offlineId);
+    session.isOnline = false;
+    session.shop = shop;
+    session.accessToken = 'gimme-access';
+    await Context.storeSession(session);
+
+    const restRequestCtx = (await withSession({
+      clientType: 'rest',
+      isOnline: false,
+      shop,
+    })) as RestWithSession;
+
+    const gqlRequestCtx = (await withSession({
+      clientType: 'graphql',
+      isOnline: false,
+      shop,
+    })) as GraphqlWithSession;
+
+    expect(restRequestCtx).toBeDefined();
+    expect(restRequestCtx.session.shop).toBe(shop);
+    expect(restRequestCtx.client).toBeInstanceOf(RestClient);
+
+    expect(gqlRequestCtx).toBeDefined();
+    expect(gqlRequestCtx.session.shop).toBe(shop);
+    expect(gqlRequestCtx.client).toBeInstanceOf(GraphqlClient);
+  });
+
+  it('returns an object containing the appropriate client and session for online && non-embedded apps', async () => {
+    Context.IS_EMBEDDED_APP = false;
+    Context.initialize(Context);
+
+    const session = new Session(`12345`);
+    session.isOnline = true;
+    session.shop = shop;
+    session.accessToken = 'gimme-access';
+    await Context.storeSession(session);
+
+    const req = {} as http.IncomingMessage;
+    const res = {} as http.ServerResponse;
+
+    const cookieId = '12345';
+
+    Cookies.prototype.get.mockImplementation(() => cookieId);
+
+    const restRequestCtx = (await withSession({
+      clientType: 'rest',
+      isOnline: true,
+      req,
+      res,
+    })) as RestWithSession;
+
+    const gqlRequestCtx = (await withSession({
+      clientType: 'graphql',
+      isOnline: true,
+      req,
+      res,
+    })) as GraphqlWithSession;
+
+    expect(restRequestCtx).toBeDefined();
+    expect(restRequestCtx.session.shop).toBe(shop);
+    expect(restRequestCtx.client).toBeInstanceOf(RestClient);
+
+    expect(gqlRequestCtx).toBeDefined();
+    expect(gqlRequestCtx.session.shop).toBe(shop);
+    expect(gqlRequestCtx.client).toBeInstanceOf(GraphqlClient);
+  });
+
+  it('returns an object with the appropriate client and session for online && embedded apps', async () => {
+    Context.IS_EMBEDDED_APP = true;
+    Context.initialize(Context);
+
+    const session = new Session(`12345`);
+    session.isOnline = true;
+    session.shop = shop;
+    session.accessToken = 'gimme-access';
+    await Context.storeSession(session);
+
+    const jwtPayload = {
+      iss: `https://${shop}`,
+      dest: `https://${shop}`,
+      aud: Context.API_KEY,
+      sub: '1',
+      exp: Date.now() / 1000 + 3600,
+      nbf: 1234,
+      iat: 1234,
+      jti: '4321',
+      sid: 'abc123',
+    };
+
+    const token = jwt.sign(jwtPayload, Context.API_SECRET_KEY, {algorithm: 'HS256'});
+    const req = {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    } as http.IncomingMessage;
+    const res = {} as http.ServerResponse;
+
+    const restRequestCtx = (await withSession({
+      clientType: 'rest',
+      isOnline: true,
+      req,
+      res,
+    })) as RestWithSession;
+
+    const gqlRequestCtx = (await withSession({
+      clientType: 'graphql',
+      isOnline: true,
+      req,
+      res,
+    })) as GraphqlWithSession;
+
+    expect(restRequestCtx).toBeDefined();
+    expect(restRequestCtx.session.shop).toBe(shop);
+    expect(restRequestCtx.client).toBeInstanceOf(RestClient);
+
+    expect(gqlRequestCtx).toBeDefined();
+    expect(gqlRequestCtx.session.shop).toBe(shop);
+    expect(gqlRequestCtx.client).toBeInstanceOf(GraphqlClient);
+  });
+});

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,27 @@
+import http from 'http';
+
+import {Session} from '../auth/session';
+import {GraphqlClient} from '../clients/graphql';
+import {RestClient} from '../clients/rest';
+
+export interface WithSessionParams {
+  clientType: 'rest' | 'graphql';
+  isOnline: boolean;
+  req?: http.IncomingMessage;
+  res?: http.ServerResponse;
+  shop?: string;
+}
+
+interface WithSessionBaseResponse {
+  session: Session;
+}
+
+export interface RestWithSession extends WithSessionBaseResponse {
+  client: RestClient;
+}
+
+export interface GraphqlWithSession extends WithSessionBaseResponse {
+  client: GraphqlClient;
+}
+
+export type WithSessionResponse = RestWithSession | GraphqlWithSession;

--- a/src/utils/with-session.ts
+++ b/src/utils/with-session.ts
@@ -1,0 +1,60 @@
+import * as ShopifyErrors from '../error';
+import {Session} from '../auth/session';
+import {GraphqlClient} from '../clients/graphql';
+import {RestClient} from '../clients/rest';
+import {Context} from '../context';
+
+import {WithSessionParams, WithSessionResponse} from './types';
+import loadOfflineSession from './load-offline-session';
+import loadCurrentSession from './load-current-session';
+
+export default async function withSession({
+  clientType,
+  isOnline,
+  req,
+  res,
+  shop,
+}: WithSessionParams): Promise<WithSessionResponse> {
+  Context.throwIfUninitialized();
+
+  let session: Session | undefined;
+  let client: RestClient | GraphqlClient;
+  if (isOnline) {
+    if (!req || !res) {
+      throw new ShopifyErrors.MissingRequiredArgument('Please pass in both the "request" and "response" objects.');
+    }
+
+    session = await loadCurrentSession(req, res);
+  } else {
+    if (!shop) {
+      throw new ShopifyErrors.MissingRequiredArgument('Please pass in a value for "shop"');
+    }
+
+    session = await loadOfflineSession(shop);
+  }
+
+  if (!session) {
+    throw new ShopifyErrors.SessionNotFound('No session found.');
+  } else if (!session.accessToken) {
+    throw new ShopifyErrors.InvalidSession('Requested session does not contain an accessToken.');
+  }
+
+  switch (clientType) {
+    case 'rest':
+      client = new RestClient(session.shop, session.accessToken);
+      return {
+        client,
+        session,
+      };
+    case 'graphql':
+      client = new GraphqlClient(session.shop, session.accessToken);
+      return {
+        client,
+        session,
+      };
+    default:
+      throw new ShopifyErrors.UnsupportedClientType(
+        `"${clientType}" is an unsupported clientType. Please use "rest" or "graphql".`,
+      );
+  }
+}


### PR DESCRIPTION
### WHAT is this pull request doing?

Adds `withSession` util/helper. This allows the user to pass in a set of parameters and receive back a client that is already hooked into the current active session (or the requested offline session), as well as the session itself. 

**For review**, I would love extra eyes on my testing setup (all lines are covered but is there anything I should change or improve?). 

Additionally, wondering if we should move this into the `clients` directory, as I think it would make sense to be able to call `ShopifyAPI.Clients.withSession(<params>)` from an end-user experience perspective. 

