### PR TITLE
Centralize logic on getting the current session id

### DIFF
--- a/src/utils/load-current-session.ts
+++ b/src/utils/load-current-session.ts
@@ -1,11 +1,8 @@
 import http from 'http';
 
 import {Context} from '../context';
-import * as ShopifyErrors from '../error';
 import {ShopifyOAuth} from '../auth/oauth/oauth';
 import {Session} from '../auth/session';
-
-import decodeSessionToken from './decode-session-token';
 
 /**
  * Loads the current user's session, based on the given request and response.
@@ -19,30 +16,10 @@ export default async function loadCurrentSession(
 ): Promise<Session | undefined> {
   Context.throwIfUninitialized();
 
-  let session: Session | undefined;
-
-  if (Context.IS_EMBEDDED_APP) {
-    const authHeader = request.headers.authorization;
-    if (authHeader) {
-      const matches = authHeader.match(/^Bearer (.+)$/);
-      if (!matches) {
-        throw new ShopifyErrors.MissingJwtTokenError('Missing Bearer token in authorization header');
-      }
-
-      const jwtPayload = decodeSessionToken(matches[1]);
-      const jwtSessionId = ShopifyOAuth.getJwtSessionId(jwtPayload.dest.replace(/^https:\/\//, ''), jwtPayload.sub);
-      session = await Context.SESSION_STORAGE.loadSession(jwtSessionId);
-    }
+  const sessionId = ShopifyOAuth.getCurrentSessionId(request, response);
+  if (!sessionId) {
+    return Promise.resolve(undefined);
   }
 
-  // We fall back to the cookie session to allow apps to load their skeleton page after OAuth, so they can set up App
-  // Bridge and get a new JWT.
-  if (!session) {
-    const sessionCookie = ShopifyOAuth.getCookieSessionId(request, response);
-    if (sessionCookie) {
-      session = await Context.SESSION_STORAGE.loadSession(sessionCookie);
-    }
-  }
-
-  return session;
+  return Context.SESSION_STORAGE.loadSession(sessionId);
 }

--- a/src/utils/test/delete-current-session.test.ts
+++ b/src/utils/test/delete-current-session.test.ts
@@ -79,22 +79,16 @@ describe('deleteCurrenSession', () => {
     await expect(() => deleteCurrentSession(req, res)).rejects.toBeInstanceOf(ShopifyErrors.SessionNotFound);
   });
 
-  it('throws an error when authorization header is missing or not a bearer token', async () => {
+  it('throws an error when authorization header is not a bearer token', async () => {
     Context.IS_EMBEDDED_APP = true;
     Context.initialize(Context);
 
-    let req = {
-      headers: {},
-    } as http.IncomingMessage;
-    const res = {} as http.ServerResponse;
-
-    await expect(() => deleteCurrentSession(req, res)).rejects.toBeInstanceOf(ShopifyErrors.MissingJwtTokenError);
-
-    req = {
+    const req = {
       headers: {
         authorization: "What's a bearer token?",
       },
     } as http.IncomingMessage;
+    const res = {} as http.ServerResponse;
 
     await expect(() => deleteCurrentSession(req, res)).rejects.toBeInstanceOf(ShopifyErrors.MissingJwtTokenError);
   });


### PR DESCRIPTION
### WHY are these changes introduced?

The previous implementation of `deleteCurrentSession` essentially replicated a previous iteration of `loadCurrentSession`, which caused errors due to them being out of sync.

### WHAT is this pull request doing?

Extracted the logic to obtain the current session id from the request into a shared method, that is now called from both `loadCurrentSession` and `deleteCurrentSession`, so they should always behave consistently.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
