### PR TITLE
Separating webhook types into their own file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 ### Added
+- Webhooks types are now exported outside the library [#91](https://github.com/shopify/shopify-node-api/pull/91)
 ### Fixed
 
 ## [0.3.1] - 2021-02-03

--- a/src/base_types.ts
+++ b/src/base_types.ts
@@ -1,0 +1,30 @@
+import {SessionStorage} from './auth/session';
+
+export interface ContextParams {
+  API_KEY: string;
+  API_SECRET_KEY: string;
+  SCOPES: string[];
+  HOST_NAME: string;
+  API_VERSION: ApiVersion;
+  IS_EMBEDDED_APP: boolean;
+  SESSION_STORAGE?: SessionStorage;
+}
+
+export enum ApiVersion {
+  April19 = '2019-04',
+  July19 = '2019-07',
+  October19 = '2019-10',
+  January20 = '2020-01',
+  April20 = '2020-04',
+  July20 = '2020-07',
+  October20 = '2020-10',
+  Unstable = 'unstable',
+  Unversioned = 'unversioned',
+}
+
+export enum ShopifyHeader {
+  AccessToken = 'X-Shopify-Access-Token',
+  Hmac = 'X-Shopify-Hmac-Sha256',
+  Topic = 'X-Shopify-Topic',
+  Domain = 'X-Shopify-Shop-Domain',
+}

--- a/src/clients/graphql/graphql_client.ts
+++ b/src/clients/graphql/graphql_client.ts
@@ -1,5 +1,5 @@
 import {Context} from '../../context';
-import {ShopifyHeader} from '../../types';
+import {ShopifyHeader} from '../../base_types';
 import {HttpClient} from '../http_client/http_client';
 import {DataType, RequestReturn} from '../http_client/types';
 

--- a/src/clients/graphql/test/graphql_client.test.ts
+++ b/src/clients/graphql/test/graphql_client.test.ts
@@ -1,5 +1,5 @@
 import '../../../test/test_helper';
-import {ShopifyHeader} from '../../../types';
+import {ShopifyHeader} from '../../../base_types';
 import {assertHttpRequest} from '../../http_client/test/test_helper';
 import {GraphqlClient} from '../graphql_client';
 

--- a/src/clients/rest/rest_client.ts
+++ b/src/clients/rest/rest_client.ts
@@ -1,7 +1,7 @@
 import querystring from 'querystring';
 
 import {Context} from '../../context';
-import {ShopifyHeader} from '../../types';
+import {ShopifyHeader} from '../../base_types';
 import {HttpClient} from '../http_client/http_client';
 import {RequestParams, GetRequestParams} from '../http_client/types';
 

--- a/src/clients/rest/test/rest_client.test.ts
+++ b/src/clients/rest/test/rest_client.test.ts
@@ -1,7 +1,7 @@
 import '../../../test/test_helper';
 import querystring from 'querystring';
 
-import {ShopifyHeader} from '../../../types';
+import {ShopifyHeader} from '../../../base_types';
 import {DataType, GetRequestParams} from '../../http_client/types';
 import {assertHttpRequest} from '../../http_client/test/test_helper';
 import {RestClient} from '../rest_client';

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,6 @@
 import * as ShopifyErrors from './error';
 import {SessionStorage, MemorySessionStorage} from './auth/session';
-import {ApiVersion, ContextParams} from './types';
+import {ApiVersion, ContextParams} from './base_types';
 
 interface ContextInterface extends ContextParams {
   SESSION_STORAGE: SessionStorage;

--- a/src/test/context.test.ts
+++ b/src/test/context.test.ts
@@ -4,7 +4,7 @@ import Cookies from 'cookies';
 
 import * as ShopifyErrors from '../error';
 import {Context} from '../context';
-import {ApiVersion, ContextParams} from '../types';
+import {ApiVersion, ContextParams} from '../base_types';
 
 jest.mock('cookies');
 

--- a/src/test/test_helper.ts
+++ b/src/test/test_helper.ts
@@ -1,7 +1,7 @@
 import {enableFetchMocks} from 'jest-fetch-mock';
 
 import {Context} from '../context';
-import {ApiVersion} from '../types';
+import {ApiVersion} from '../base_types';
 import {MemorySessionStorage} from '../auth/session';
 
 enableFetchMocks();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,33 +1,4 @@
-import {SessionStorage} from './auth/session';
-
-export interface ContextParams {
-  API_KEY: string;
-  API_SECRET_KEY: string;
-  SCOPES: string[];
-  HOST_NAME: string;
-  API_VERSION: ApiVersion;
-  IS_EMBEDDED_APP: boolean;
-  SESSION_STORAGE?: SessionStorage;
-}
-
-export enum ApiVersion {
-  April19 = '2019-04',
-  July19 = '2019-07',
-  October19 = '2019-10',
-  January20 = '2020-01',
-  April20 = '2020-04',
-  July20 = '2020-07',
-  October20 = '2020-10',
-  Unstable = 'unstable',
-  Unversioned = 'unversioned',
-}
-
-export enum ShopifyHeader {
-  AccessToken = 'X-Shopify-Access-Token',
-  Hmac = 'X-Shopify-Hmac-Sha256',
-  Topic = 'X-Shopify-Topic',
-  Domain = 'X-Shopify-Shop-Domain',
-}
-
+export * from './base_types';
 export * from './auth/oauth/types';
 export * from './clients/types';
+export * from './webhooks/types';

--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -3,68 +3,20 @@ import {createHmac} from 'crypto';
 import {StatusCode} from '@shopify/network';
 
 import {GraphqlClient} from '../clients/graphql/graphql_client';
-import {ShopifyHeader, ApiVersion} from '../types';
+import {ShopifyHeader} from '../base_types';
 import ShopifyUtilities from '../utils';
 import {Context} from '../context';
 import * as ShopifyErrors from '../error';
 
-export enum DeliveryMethod {
-  Http = 'http',
-  EventBridge = 'eventbridge',
-}
-
-export type WebhookHandlerFunction = (
-  topic: string,
-  shop_domain: string,
-  body: Buffer
-) => void;
-
-export interface RegisterOptions {
-  // See https://shopify.dev/docs/admin-api/graphql/reference/events/webhooksubscriptiontopic for available topics
-  topic: string;
-  path: string;
-  shop: string;
-  accessToken: string;
-  apiVersion: ApiVersion;
-  deliveryMethod?: DeliveryMethod;
-  webhookHandler: WebhookHandlerFunction;
-}
-
-export interface RegisterReturn {
-  success: boolean;
-  result: unknown;
-}
-
-interface WebhookRegistryEntry {
-  path: string;
-  topic: string;
-  webhookHandler: WebhookHandlerFunction;
-}
-
-export interface ProcessOptions {
-  headers: Record<string, string>;
-  body: Buffer;
-}
-
-export interface ProcessReturn {
-  statusCode: StatusCode;
-  headers: Record<string, string>;
-}
-
-interface WebhookCheckResponseNode {
-  node: {
-    id: string;
-    callbackUrl: string;
-  };
-}
-
-interface WebhookCheckResponse {
-  data: {
-    webhookSubscriptions: {
-      edges: WebhookCheckResponseNode[];
-    };
-  };
-}
+import {
+  DeliveryMethod,
+  RegisterOptions,
+  RegisterReturn,
+  WebhookRegistryEntry,
+  ProcessOptions,
+  ProcessReturn,
+  WebhookCheckResponse,
+} from './types';
 
 interface RegistryInterface {
   webhookRegistry: WebhookRegistryEntry[];

--- a/src/webhooks/test/registry.test.ts
+++ b/src/webhooks/test/registry.test.ts
@@ -3,8 +3,8 @@ import {createHmac} from 'crypto';
 
 import {Method, Header, StatusCode} from '@shopify/network';
 
-import {DeliveryMethod, ProcessReturn, RegisterOptions} from '../registry';
-import {ApiVersion, ShopifyHeader} from '../../types';
+import {DeliveryMethod, ProcessReturn, RegisterOptions} from '../types';
+import {ApiVersion, ShopifyHeader} from '../../base_types';
 import {Context} from '../../context';
 import {DataType} from '../../clients/types';
 import {assertHttpRequest} from '../../clients/http_client/test/test_helper';

--- a/src/webhooks/types.ts
+++ b/src/webhooks/types.ts
@@ -1,0 +1,61 @@
+import {StatusCode} from '@shopify/network';
+
+import {ApiVersion} from '../base_types';
+
+export enum DeliveryMethod {
+  Http = 'http',
+  EventBridge = 'eventbridge',
+}
+
+type WebhookHandlerFunction = (
+  topic: string,
+  shop_domain: string,
+  body: Buffer
+) => void;
+
+export interface RegisterOptions {
+  // See https://shopify.dev/docs/admin-api/graphql/reference/events/webhooksubscriptiontopic for available topics
+  topic: string;
+  path: string;
+  shop: string;
+  accessToken: string;
+  apiVersion: ApiVersion;
+  deliveryMethod?: DeliveryMethod;
+  webhookHandler: WebhookHandlerFunction;
+}
+
+export interface RegisterReturn {
+  success: boolean;
+  result: unknown;
+}
+
+export interface WebhookRegistryEntry {
+  path: string;
+  topic: string;
+  webhookHandler: WebhookHandlerFunction;
+}
+
+export interface ProcessOptions {
+  headers: Record<string, string>;
+  body: Buffer;
+}
+
+export interface ProcessReturn {
+  statusCode: StatusCode;
+  headers: Record<string, string>;
+}
+
+interface WebhookCheckResponseNode {
+  node: {
+    id: string;
+    callbackUrl: string;
+  };
+}
+
+export interface WebhookCheckResponse {
+  data: {
+    webhookSubscriptions: {
+      edges: WebhookCheckResponseNode[];
+    };
+  };
+}


### PR DESCRIPTION
### WHY are these changes introduced?

The webhooks module was still exporting types in the same file as its implementation file, which made it tricky to surface them outside the library.

### WHAT is this pull request doing?

Separates the webhooks types into its own file, which then gets exported alongside the other types in the library.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [X] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
