### PR TITLE
Improvements on CustomSessionStorage and its docs

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -8,24 +8,27 @@ Before you start writing your application, please note that the Shopify library 
 
 `MemorySessionStorage` is **purposely** designed to be a single-process, development-only solution. It **will leak** memory in most cases and delete all sessions when your app restarts. You should **never** use it in production apps. In order to use your preferred storage choice with the Shopify library, you'll need to perform a few steps:
 
-- Create a class that extends the `SessionStorage` interface, and implements the following methods: `loadSession`, `storeSession`, and `deleteSession`.
-- _OR_ Create a new instance of `CustomSessionStorage`, providing callbacks for these methods.
-- Implement those methods so that they perform the necessary actions in your app's storage.
-- Provide an instance of that class when calling `Shopify.Context.initialize`, for example:
+- Create a new instance of `CustomSessionStorage`, passing in callbacks to store, load, and delete sessions.
+- Implement those callbacks so that they perform the necessary actions in your preferred storage method.
+- Provide that instance when calling `Shopify.Context.initialize`, for example:
 ```ts
   // src/my_session_storage.ts
-  import { SessionStorage, Session } from '@shopify/shopify-api';
+  import { SessionStorage } from '@shopify/shopify-api';
 
-  class MySessionStorage extends SessionStorage {
-    public async loadSession(sessionId: string) { ... }
-    public async storeSession(session: Session) { ... }
-    public async deleteSession(sessionId: string) { ... }
-  }
+  async function storeCallback(session: Session): Promise<boolean> { ... }
+  async function loadCallback(id: string): Promise<Session | undefined> { ... }
+  async function deleteCallback(id: string): Promise<boolean> { ... }
+
+  const mySessionStorage = new Shopify.Session.CustomSessionStorage(
+    storeCallback,
+    loadCallback,
+    deleteCallback,
+  );
 
   // src/index.ts
   Shopify.Context.initialize({
     ... // app settings
-    SESSION_STORAGE: new MySessionStorage(),
+    SESSION_STORAGE: mySessionStorage(),
   });
 ```
 

--- a/src/auth/oauth/test/oauth.test.ts
+++ b/src/auth/oauth/test/oauth.test.ts
@@ -55,9 +55,9 @@ describe('beginAuth', () => {
 
   test('throws SessionStorageErrors when storeSession returns false', async () => {
     const storage = new CustomSessionStorage(
-      () => false,
-      () => new Session(shop),
-      () => true,
+      () => Promise.resolve(false),
+      () => Promise.resolve(new Session(shop)),
+      () => Promise.resolve(true),
     );
     Context.SESSION_STORAGE = storage;
 
@@ -223,9 +223,9 @@ describe('validateAuthCallback', () => {
     // create new storage with broken storeCallback for validateAuthCallback to use
     /* eslint-disable-next-line require-atomic-updates */
     Context.SESSION_STORAGE = new CustomSessionStorage(
-      () => false,
-      () => session,
-      () => true,
+      () => Promise.resolve(false),
+      () => Promise.resolve(session),
+      () => Promise.resolve(true),
     );
 
     await expect(ShopifyOAuth.validateAuthCallback(req, res, testCallbackQuery)).rejects.toThrow(

--- a/src/auth/session/storage/custom.ts
+++ b/src/auth/session/storage/custom.ts
@@ -4,9 +4,9 @@ import * as ShopifyErrors from '../../../error';
 
 export class CustomSessionStorage implements SessionStorage {
   constructor(
-    readonly storeCallback: (session: Session) => boolean,
-    readonly loadCallback: (id: string) => Session | undefined,
-    readonly deleteCallback: (id: string) => boolean,
+    readonly storeCallback: (session: Session) => Promise<boolean>,
+    readonly loadCallback: (id: string) => Promise<Session | undefined>,
+    readonly deleteCallback: (id: string) => Promise<boolean>,
   ) {
     this.storeCallback = storeCallback;
     this.loadCallback = loadCallback;
@@ -15,7 +15,7 @@ export class CustomSessionStorage implements SessionStorage {
 
   public async storeSession(session: Session): Promise<boolean> {
     try {
-      return this.storeCallback(session);
+      return await this.storeCallback(session);
     } catch (error) {
       throw new ShopifyErrors.SessionStorageError(
         `CustomSessionStorage failed to store a session. Error Details: ${error}`,
@@ -26,7 +26,7 @@ export class CustomSessionStorage implements SessionStorage {
   public async loadSession(id: string): Promise<Session | undefined> {
     let result: Session | undefined;
     try {
-      result = this.loadCallback(id);
+      result = await this.loadCallback(id);
     } catch (error) {
       throw new ShopifyErrors.SessionStorageError(
         `CustomSessionStorage failed to load a session. Error Details: ${error}`,
@@ -47,7 +47,7 @@ export class CustomSessionStorage implements SessionStorage {
 
   public async deleteSession(id: string): Promise<boolean> {
     try {
-      return this.deleteCallback(id);
+      return await this.deleteCallback(id);
     } catch (error) {
       throw new ShopifyErrors.SessionStorageError(
         `CustomSessionStorage failed to delete a session. Error Details: ${error}`,

--- a/src/auth/session/test/custom.test.ts
+++ b/src/auth/session/test/custom.test.ts
@@ -14,16 +14,16 @@ test('can use custom session storage', async () => {
   const storage = new CustomSessionStorage(
     () => {
       storeCalled = true;
-      return true;
+      return Promise.resolve(true);
     },
     () => {
       loadCalled = true;
-      return session;
+      return Promise.resolve(session);
     },
     () => {
       deleteCalled = true;
       session = undefined;
-      return true;
+      return Promise.resolve(true);
     },
   );
 
@@ -57,9 +57,9 @@ test('custom session storage failures and exceptions are raised', () => {
   const session = new Session(sessionId);
 
   let storage = new CustomSessionStorage(
-    () => false,
-    () => undefined,
-    () => false,
+    () => Promise.resolve(false),
+    () => Promise.resolve(undefined),
+    () => Promise.resolve(false),
   );
 
   expect(storage.storeSession(session)).resolves.toBe(false);
@@ -67,15 +67,9 @@ test('custom session storage failures and exceptions are raised', () => {
   expect(storage.deleteSession(sessionId)).resolves.toBe(false);
 
   storage = new CustomSessionStorage(
-    () => {
-      throw Error('Failed to store!');
-    },
-    () => {
-      throw Error('Failed to load!');
-    },
-    () => {
-      throw Error('Failed to delete!');
-    },
+    () => Promise.reject(new Error('Failed to store!')),
+    () => Promise.reject(new Error('Failed to load!')),
+    () => Promise.reject(new Error('Failed to delete!')),
   );
 
   const expectedStore = expect(storage.storeSession(session)).rejects;
@@ -91,9 +85,9 @@ test('custom session storage failures and exceptions are raised', () => {
   expectedDelete.toThrow(/Error: Failed to delete!/);
 
   storage = new CustomSessionStorage(
-    () => true,
-    () => 'this is not a Session' as any,
-    () => true,
+    () => Promise.resolve(true),
+    () => Promise.resolve('this is not a Session' as any),
+    () => Promise.resolve(true),
   );
 
   expect(storage.loadSession(sessionId)).rejects.toThrow(SessionStorageError);


### PR DESCRIPTION
### WHY are these changes introduced?

Our code didn't expect that the callbacks from `CustomSessionStorage` would ever need to run asynchronous code, which is very unlikely, so we need to make sure that we allow Promises to be used for those.

### WHAT is this pull request doing?

Changing the return type of the callbacks to be Promises rather than plain objects, and updating the README docs to suggest `CustomSessionStorage` as the way to go rather than extending `SessionStorage`, because we get the benefit of validating the callbacks under the Custom storage.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)