### PR TITLE
Fail on webhooks if no body is given

### DIFF
--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -184,24 +184,26 @@ const WebhooksRegistry: RegistryInterface = {
   },
 
   process({headers, body}: ProcessOptions): ProcessReturn {
+    if (!body.length) {
+      throw new ShopifyErrors.MissingRequiredArgument('No body was received when processing webhook');
+    }
+
     let hmac: string | undefined;
     let topic: string | undefined;
     let domain: string | undefined;
-    for (const header in headers) {
-      if (header) {
-        switch (header.toLowerCase()) {
-          case ShopifyHeader.Hmac.toLowerCase():
-            hmac = headers[header];
-            break;
-          case ShopifyHeader.Topic.toLowerCase():
-            topic = headers[header];
-            break;
-          case ShopifyHeader.Domain.toLowerCase():
-            domain = headers[header];
-            break;
-        }
+    Object.entries(headers).map(([header, value]) => {
+      switch (header.toLowerCase()) {
+        case ShopifyHeader.Hmac.toLowerCase():
+          hmac = value;
+          break;
+        case ShopifyHeader.Topic.toLowerCase():
+          topic = value;
+          break;
+        case ShopifyHeader.Domain.toLowerCase():
+          domain = value;
+          break;
       }
-    }
+    });
 
     const missingHeaders = [];
     if (!hmac) {

--- a/src/webhooks/test/registry.test.ts
+++ b/src/webhooks/test/registry.test.ts
@@ -338,6 +338,18 @@ describe('ShopifyWebhooks.Registry.process', () => {
     expect(result.statusCode).toBe(StatusCode.Forbidden);
   });
 
+  it('fails if the given body is empty', () => {
+    ShopifyWebhooks.Registry.webhookRegistry.push({
+      path: '/webhooks',
+      topic: 'NONSENSE_TOPIC',
+      webhookHandler: genericWebhookHandler,
+    });
+
+    expect(() => ShopifyWebhooks.Registry.process({headers: headers(), body: Buffer.from('', 'utf8')})).toThrow(
+      ShopifyErrors.MissingRequiredArgument,
+    );
+  });
+
   it('fails if the any of the required headers are missing', () => {
     ShopifyWebhooks.Registry.webhookRegistry.push({
       path: '/webhooks',


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, if a webhook `process` is called without a body we just fail when we try to read its contents, which makes it hard to discern what's happening.

### WHAT is this pull request doing?

Pre-checking that the given body isn't empty, and throwing a specific error if it is.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
