### PR TITLE
Changed webhook processing to be Promise-based

### DIFF
--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -33,7 +33,7 @@ interface RegistryInterface {
    *
    * @param options Parameters required to process a webhook message, including headers and message body
    */
-  process(options: ProcessOptions): ProcessReturn;
+  process(options: ProcessOptions): Promise<ProcessReturn>;
 
   /**
    * Confirms that the given path is a webhook path
@@ -183,7 +183,7 @@ const WebhooksRegistry: RegistryInterface = {
     return {success, result: body};
   },
 
-  process({headers, body}: ProcessOptions): ProcessReturn {
+  async process({headers, body}: ProcessOptions): Promise<ProcessReturn> {
     if (!body.length) {
       throw new ShopifyErrors.MissingRequiredArgument('No body was received when processing webhook');
     }
@@ -240,7 +240,7 @@ const WebhooksRegistry: RegistryInterface = {
       );
 
       if (webhookEntry) {
-        webhookEntry.webhookHandler(graphqlTopic, domain as string, body);
+        await webhookEntry.webhookHandler(graphqlTopic, domain as string, body);
         result.statusCode = StatusCode.Ok;
         result.headers = {};
       }

--- a/src/webhooks/test/registry.test.ts
+++ b/src/webhooks/test/registry.test.ts
@@ -75,8 +75,9 @@ const failResponse = {
   data: {},
 };
 
-function genericWebhookHandler(topic: string, shopDomain: string, body: Buffer) {
-  if (topic && shopDomain && body) { // eslint-disable-lint no-empty
+async function genericWebhookHandler(topic: string, shopDomain: string, body: Buffer): Promise<void> {
+  if (!topic || !shopDomain || !body) {
+    throw new Error('Missing webhook parameters');
   }
 }
 
@@ -285,7 +286,7 @@ describe('ShopifyWebhooks.Registry.process', () => {
       webhookHandler: genericWebhookHandler,
     });
 
-    const result: ProcessReturn = ShopifyWebhooks.Registry.process({
+    const result: ProcessReturn = await ShopifyWebhooks.Registry.process({
       headers: headers({hmac: hmac(Context.API_SECRET_KEY, rawBody.toString('utf8'))}),
       body: rawBody,
     });
@@ -300,7 +301,7 @@ describe('ShopifyWebhooks.Registry.process', () => {
       webhookHandler: genericWebhookHandler,
     });
 
-    const result: ProcessReturn = ShopifyWebhooks.Registry.process({
+    const result: ProcessReturn = await ShopifyWebhooks.Registry.process({
       headers: headers({hmac: hmac(Context.API_SECRET_KEY, rawBody.toString('utf8')), lowercase: true}),
       body: rawBody,
     });
@@ -315,7 +316,7 @@ describe('ShopifyWebhooks.Registry.process', () => {
       webhookHandler: genericWebhookHandler,
     });
 
-    const result: ProcessReturn = ShopifyWebhooks.Registry.process({
+    const result: ProcessReturn = await ShopifyWebhooks.Registry.process({
       headers: headers({hmac: hmac(Context.API_SECRET_KEY, rawBody.toString('utf8'))}),
       body: rawBody,
     });
@@ -330,7 +331,7 @@ describe('ShopifyWebhooks.Registry.process', () => {
       webhookHandler: genericWebhookHandler,
     });
 
-    const result: ProcessReturn = ShopifyWebhooks.Registry.process({
+    const result: ProcessReturn = await ShopifyWebhooks.Registry.process({
       headers: headers({hmac: hmac('incorrect secret', rawBody.toString('utf8'))}),
       body: rawBody,
     });
@@ -338,34 +339,34 @@ describe('ShopifyWebhooks.Registry.process', () => {
     expect(result.statusCode).toBe(StatusCode.Forbidden);
   });
 
-  it('fails if the given body is empty', () => {
+  it('fails if the given body is empty', async () => {
     ShopifyWebhooks.Registry.webhookRegistry.push({
       path: '/webhooks',
       topic: 'NONSENSE_TOPIC',
       webhookHandler: genericWebhookHandler,
     });
 
-    expect(() => ShopifyWebhooks.Registry.process({headers: headers(), body: Buffer.from('', 'utf8')})).toThrow(
+    expect(() => ShopifyWebhooks.Registry.process({headers: headers(), body: Buffer.from('', 'utf8')})).rejects.toThrow(
       ShopifyErrors.MissingRequiredArgument,
     );
   });
 
-  it('fails if the any of the required headers are missing', () => {
+  it('fails if the any of the required headers are missing', async () => {
     ShopifyWebhooks.Registry.webhookRegistry.push({
       path: '/webhooks',
       topic: 'NONSENSE_TOPIC',
       webhookHandler: genericWebhookHandler,
     });
 
-    expect(() => ShopifyWebhooks.Registry.process({headers: headers({hmac: ''}), body: rawBody})).toThrow(
+    expect(() => ShopifyWebhooks.Registry.process({headers: headers({hmac: ''}), body: rawBody})).rejects.toThrow(
       ShopifyErrors.InvalidWebhookError,
     );
 
-    expect(() => ShopifyWebhooks.Registry.process({headers: headers({topic: ''}), body: rawBody})).toThrow(
+    expect(() => ShopifyWebhooks.Registry.process({headers: headers({topic: ''}), body: rawBody})).rejects.toThrow(
       ShopifyErrors.InvalidWebhookError,
     );
 
-    expect(() => ShopifyWebhooks.Registry.process({headers: headers({domain: ''}), body: rawBody})).toThrow(
+    expect(() => ShopifyWebhooks.Registry.process({headers: headers({domain: ''}), body: rawBody})).rejects.toThrow(
       ShopifyErrors.InvalidWebhookError,
     );
   });

--- a/src/webhooks/types.ts
+++ b/src/webhooks/types.ts
@@ -11,7 +11,7 @@ type WebhookHandlerFunction = (
   topic: string,
   shop_domain: string,
   body: Buffer
-) => void;
+) => Promise<void>;
 
 export interface RegisterOptions {
   // See https://shopify.dev/docs/admin-api/graphql/reference/events/webhooksubscriptiontopic for available topics


### PR DESCRIPTION
### WHY are these changes introduced?

Our current webhook handling code assumes all handlers will return immediately, which is unlikely in real-world scenarios. We should support Promises to make sure apps can call async functions within webhook handlers.

### WHAT is this pull request doing?

Changing the expected return type of webhook handlers to be Promises rather than just void. 

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [X] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
