### PR TITLE
Removing unused API version param from webhooks

### DIFF
--- a/src/webhooks/test/registry.test.ts
+++ b/src/webhooks/test/registry.test.ts
@@ -4,7 +4,7 @@ import {createHmac} from 'crypto';
 import {Method, Header, StatusCode} from '@shopify/network';
 
 import {DeliveryMethod, ProcessReturn, RegisterOptions} from '../types';
-import {ApiVersion, ShopifyHeader} from '../../base_types';
+import {ShopifyHeader} from '../../base_types';
 import {Context} from '../../context';
 import {DataType} from '../../clients/types';
 import {assertHttpRequest} from '../../clients/http_client/test/test_helper';
@@ -93,7 +93,6 @@ describe('ShopifyWebhooks.Registry.register', () => {
       topic: 'PRODUCTS_CREATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
-      apiVersion: ApiVersion.Unstable,
       webhookHandler: genericWebhookHandler,
     };
 
@@ -113,7 +112,6 @@ describe('ShopifyWebhooks.Registry.register', () => {
       topic: 'PRODUCTS_CREATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
-      apiVersion: ApiVersion.Unstable,
       webhookHandler: genericWebhookHandler,
     };
 
@@ -133,7 +131,6 @@ describe('ShopifyWebhooks.Registry.register', () => {
       topic: 'PRODUCTS_CREATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
-      apiVersion: ApiVersion.Unstable,
       deliveryMethod: DeliveryMethod.EventBridge,
       webhookHandler: genericWebhookHandler,
     };
@@ -154,7 +151,6 @@ describe('ShopifyWebhooks.Registry.register', () => {
       topic: 'PRODUCTS_CREATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
-      apiVersion: ApiVersion.Unstable,
       webhookHandler: genericWebhookHandler,
     };
 
@@ -174,7 +170,6 @@ describe('ShopifyWebhooks.Registry.register', () => {
       topic: 'PRODUCTS_CREATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
-      apiVersion: ApiVersion.Unstable,
       deliveryMethod: DeliveryMethod.EventBridge,
       webhookHandler: genericWebhookHandler,
     };
@@ -194,7 +189,6 @@ describe('ShopifyWebhooks.Registry.register', () => {
       topic: 'PRODUCTS_CREATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
-      apiVersion: ApiVersion.Unstable,
       deliveryMethod: DeliveryMethod.EventBridge,
       webhookHandler: genericWebhookHandler,
     };
@@ -214,7 +208,6 @@ describe('ShopifyWebhooks.Registry.register', () => {
       topic: 'PRODUCTS_CREATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
-      apiVersion: ApiVersion.Unstable,
       deliveryMethod: 'Something else',
       webhookHandler: genericWebhookHandler,
     };
@@ -231,7 +224,6 @@ describe('ShopifyWebhooks.Registry.register', () => {
       topic: 'PRODUCTS_CREATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
-      apiVersion: ApiVersion.Unstable,
       webhookHandler: genericWebhookHandler,
     };
     await ShopifyWebhooks.Registry.register(webhook);
@@ -245,7 +237,6 @@ describe('ShopifyWebhooks.Registry.register', () => {
       topic: 'PRODUCTS_UPDATE',
       accessToken: 'some token',
       shop: 'shop1.myshopify.io',
-      apiVersion: ApiVersion.Unstable,
       webhookHandler: genericWebhookHandler,
     };
     await ShopifyWebhooks.Registry.register(webhook);
@@ -459,7 +450,7 @@ function assertWebhookCheckRequest(webhook: RegisterOptions) {
   assertHttpRequest(
     Method.Post.toString(),
     webhook.shop,
-    `/admin/api/${webhook.apiVersion}/graphql.json`,
+    `/admin/api/${Context.API_VERSION}/graphql.json`,
     {
       [Header.ContentType]: DataType.GraphQL.toString(),
       [ShopifyHeader.AccessToken]: webhook.accessToken,
@@ -472,7 +463,7 @@ function assertWebhookRegistrationRequest(webhook: RegisterOptions, webhookId?: 
   assertHttpRequest(
     Method.Post.toString(),
     webhook.shop,
-    `/admin/api/${webhook.apiVersion}/graphql.json`,
+    `/admin/api/${Context.API_VERSION}/graphql.json`,
     {
       [Header.ContentType]: DataType.GraphQL.toString(),
       [ShopifyHeader.AccessToken]: webhook.accessToken,

--- a/src/webhooks/types.ts
+++ b/src/webhooks/types.ts
@@ -1,7 +1,5 @@
 import {StatusCode} from '@shopify/network';
 
-import {ApiVersion} from '../base_types';
-
 export enum DeliveryMethod {
   Http = 'http',
   EventBridge = 'eventbridge',
@@ -19,7 +17,6 @@ export interface RegisterOptions {
   path: string;
   shop: string;
   accessToken: string;
-  apiVersion: ApiVersion;
   deliveryMethod?: DeliveryMethod;
   webhookHandler: WebhookHandlerFunction;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Once we moved to using the GraphQL client for webhooks, we no longer honour the `apiVersion` param for them, instead relying on the default `Context` setting, so that param is currently innocuous.

### WHAT is this pull request doing?

Removing the unused param.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
