### PR TITLE
Use cryptographically random bytes to generate nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 - Webhooks types are now exported outside the library [#91](https://github.com/shopify/shopify-node-api/pull/91)
 ### Fixed
+- Use cryptographically random bytes to generate nonce [#98](https://github.com/Shopify/shopify-node-api/pull/98)
 
 ## [0.3.1] - 2021-02-03
 ### Fixed

--- a/src/utils/nonce.ts
+++ b/src/utils/nonce.ts
@@ -1,11 +1,14 @@
+import crypto from 'crypto';
+
 export default function nonce(): string {
   const length = 15;
-  let nonce = '';
+  const bytes = crypto.randomBytes(length);
 
-  for (let i = 0; i <= 3; i++) {
-    nonce += Math.round(Number(new Date()) * Math.random());
-  }
+  const nonce = bytes
+    .map((byte) => {
+      return byte % 10;
+    })
+    .join('');
 
-  const str = nonce.substr(nonce.length - length);
-  return str;
+  return nonce;
 }


### PR DESCRIPTION
### WHY are these changes introduced?
The current implementation of the nonce generating function is based off of the current date (in seconds), and `Math.random`. `Math.random` is not cryptographically secure and as a result, the numbers can be predicted. Switching to using cryptographically random bytes to generate the nonce will allow for a more truly random numbers.

### WHAT is this pull request doing?

This PR makes use of node's `crypto.randomBytes()` function to generate 15 random bytes. I then mod by 10 to extract the last digit from the byte and use that as a digit in the nonce.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
