### PR TITLE
Add support for private apps

### DIFF
--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -39,6 +39,7 @@ const ShopifyOAuth = {
     isOnline = false,
   ): Promise<string> {
     Context.throwIfUninitialized();
+    Context.throwIfPrivateApp('Cannot perform OAuth for private apps');
 
     const cookies = new Cookies(request, response, {
       keys: [Context.API_SECRET_KEY],
@@ -98,6 +99,7 @@ const ShopifyOAuth = {
     query: AuthQuery,
   ): Promise<void> {
     Context.throwIfUninitialized();
+    Context.throwIfPrivateApp('Cannot perform OAuth for private apps');
 
     const cookies = new Cookies(request, response, {
       keys: [Context.API_SECRET_KEY],

--- a/src/auth/oauth/test/oauth.test.ts
+++ b/src/auth/oauth/test/oauth.test.ts
@@ -121,6 +121,13 @@ describe('beginAuth', () => {
 
     expect(authRoute).toBe(`https://${shop}/admin/oauth/authorize?${expectedQueryString}`);
   });
+
+  test('fails to start if the app is private', () => {
+    Context.IS_PRIVATE_APP = true;
+    Context.initialize(Context);
+
+    expect(ShopifyOAuth.beginAuth(req, res, shop, '/some-callback', true)).rejects.toThrow(ShopifyErrors.PrivateAppError);
+  });
 });
 
 describe('validateAuthCallback', () => {
@@ -384,5 +391,12 @@ describe('validateAuthCallback', () => {
     const currentSession = await loadCurrentSession(jwtReq, jwtRes);
     expect(currentSession).not.toBe(null);
     expect(currentSession?.id).toEqual(jwtSessionId);
+  });
+
+  test('fails to run if the app is private', () => {
+    Context.IS_PRIVATE_APP = true;
+    Context.initialize(Context);
+
+    expect(ShopifyOAuth.validateAuthCallback(req, res, {} as AuthQuery)).rejects.toThrow(ShopifyErrors.PrivateAppError);
   });
 });

--- a/src/base_types.ts
+++ b/src/base_types.ts
@@ -7,6 +7,7 @@ export interface ContextParams {
   HOST_NAME: string;
   API_VERSION: ApiVersion;
   IS_EMBEDDED_APP: boolean;
+  IS_PRIVATE_APP?: boolean;
   SESSION_STORAGE?: SessionStorage;
 }
 

--- a/src/clients/graphql/test/graphql_client.test.ts
+++ b/src/clients/graphql/test/graphql_client.test.ts
@@ -2,6 +2,8 @@ import '../../../test/test_helper';
 import {ShopifyHeader} from '../../../base_types';
 import {assertHttpRequest} from '../../http_client/test/test_helper';
 import {GraphqlClient} from '../graphql_client';
+import {Context} from '../../../context';
+import * as ShopifyErrors from '../../../error';
 
 const DOMAIN = 'shop.myshopify.com';
 const QUERY = `
@@ -26,7 +28,12 @@ describe('GraphQL client', () => {
     fetchMock.mockResponseOnce(JSON.stringify(successResponse));
 
     await expect(client.query({data: QUERY})).resolves.toEqual(buildExpectedResponse(successResponse));
-    assertHttpRequest('POST', DOMAIN, '/admin/api/unstable/graphql.json', {}, QUERY);
+    assertHttpRequest({
+      method: 'POST',
+      domain: DOMAIN,
+      path: '/admin/api/unstable/graphql.json',
+      data: QUERY,
+    });
   });
 
   it('merges custom headers with default', async () => {
@@ -40,7 +47,37 @@ describe('GraphQL client', () => {
     await expect(client.query({extraHeaders: customHeader, data: QUERY})).resolves.toEqual(buildExpectedResponse(successResponse));
 
     customHeader[ShopifyHeader.AccessToken] = 'bork';
-    assertHttpRequest('POST', DOMAIN, '/admin/api/unstable/graphql.json', customHeader, QUERY);
+    assertHttpRequest({
+      method: 'POST',
+      domain: DOMAIN,
+      path: '/admin/api/unstable/graphql.json',
+      headers: customHeader,
+      data: QUERY,
+    });
+  });
+
+  it('adapts to private app requests', async () => {
+    Context.IS_PRIVATE_APP = true;
+    Context.initialize(Context);
+
+    const client: GraphqlClient = new GraphqlClient(DOMAIN);
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+
+    const customHeaders: Record<string, string> = {};
+    customHeaders[ShopifyHeader.AccessToken] = 'test_secret_key';
+
+    await expect(client.query({data: QUERY})).resolves.toEqual(buildExpectedResponse(successResponse));
+    assertHttpRequest({
+      method: 'POST',
+      domain: DOMAIN,
+      path: '/admin/api/unstable/graphql.json',
+      data: QUERY,
+      headers: customHeaders,
+    });
+  });
+
+  it('fails to instantiate without access token', () => {
+    expect(() => new GraphqlClient(DOMAIN)).toThrow(ShopifyErrors.MissingRequiredArgument);
   });
 });
 

--- a/src/clients/http_client/test/http_client.test.ts
+++ b/src/clients/http_client/test/http_client.test.ts
@@ -26,7 +26,7 @@ describe('HTTP client', () => {
     fetchMock.mockResponseOnce(buildMockResponse(successResponse));
 
     await expect(client.get({path: '/url/path'})).resolves.toEqual(buildExpectedResponse(successResponse));
-    assertHttpRequest('GET', domain, '/url/path');
+    assertHttpRequest({method: 'GET', domain, path: '/url/path'});
   });
 
   it('can make POST request with type JSON', async () => {
@@ -46,13 +46,13 @@ describe('HTTP client', () => {
     };
 
     await expect(client.post(postParams)).resolves.toEqual(buildExpectedResponse(successResponse));
-    assertHttpRequest(
-      'POST',
+    assertHttpRequest({
+      method: 'POST',
       domain,
-      '/url/path',
-      {'Content-Type': DataType.JSON.toString()},
-      JSON.stringify(postData),
-    );
+      path: '/url/path',
+      headers: {'Content-Type': DataType.JSON.toString()},
+      data: JSON.stringify(postData),
+    });
   });
 
   it('can make POST request with type JSON and data is already formatted', async () => {
@@ -72,13 +72,13 @@ describe('HTTP client', () => {
     };
 
     await expect(client.post(postParams)).resolves.toEqual(buildExpectedResponse(successResponse));
-    assertHttpRequest(
-      'POST',
+    assertHttpRequest({
+      method: 'POST',
       domain,
-      '/url/path',
-      {'Content-Type': DataType.JSON.toString()},
-      JSON.stringify(postData),
-    );
+      path: '/url/path',
+      headers: {'Content-Type': DataType.JSON.toString()},
+      data: JSON.stringify(postData),
+    });
   });
 
   it('can make POST request with zero-length JSON', async () => {
@@ -93,7 +93,7 @@ describe('HTTP client', () => {
     };
 
     await expect(client.post(postParams)).resolves.toEqual(buildExpectedResponse(successResponse));
-    assertHttpRequest('POST', domain, '/url/path', {}, null);
+    assertHttpRequest({method: 'POST', domain, path: '/url/path'});
   });
 
   it('can make POST request with form-data type', async () => {
@@ -113,13 +113,13 @@ describe('HTTP client', () => {
     };
 
     await expect(client.post(postParams)).resolves.toEqual(buildExpectedResponse(successResponse));
-    assertHttpRequest(
-      'POST',
+    assertHttpRequest({
+      method: 'POST',
       domain,
-      '/url/path',
-      {'Content-Type': DataType.URLEncoded.toString()},
-      querystring.stringify(postData),
-    );
+      path: '/url/path',
+      headers: {'Content-Type': DataType.URLEncoded.toString()},
+      data: querystring.stringify(postData),
+    });
   });
 
   it('can make POST request with form-data type and data is already formatted', async () => {
@@ -139,13 +139,13 @@ describe('HTTP client', () => {
     };
 
     await expect(client.post(postParams)).resolves.toEqual(buildExpectedResponse(successResponse));
-    assertHttpRequest(
-      'POST',
+    assertHttpRequest({
+      method: 'POST',
       domain,
-      '/url/path',
-      {'Content-Type': DataType.URLEncoded.toString()},
-      querystring.stringify(postData),
-    );
+      path: '/url/path',
+      headers: {'Content-Type': DataType.URLEncoded.toString()},
+      data: querystring.stringify(postData),
+    });
   });
 
   it('can make POST request with GraphQL type', async () => {
@@ -173,7 +173,13 @@ describe('HTTP client', () => {
     };
 
     await expect(client.post(postParams)).resolves.toEqual(buildExpectedResponse(successResponse));
-    assertHttpRequest('POST', domain, '/url/path', {'Content-Type': DataType.GraphQL.toString()}, graphqlQuery);
+    assertHttpRequest({
+      method: 'POST',
+      domain,
+      path: '/url/path',
+      headers: {'Content-Type': DataType.GraphQL.toString()},
+      data: graphqlQuery,
+    });
   });
 
   it('can make PUT request with type JSON', async () => {
@@ -193,13 +199,13 @@ describe('HTTP client', () => {
     };
 
     await expect(client.put(putParams)).resolves.toEqual(buildExpectedResponse(successResponse));
-    assertHttpRequest(
-      'PUT',
+    assertHttpRequest({
+      method: 'PUT',
       domain,
-      '/url/path/123',
-      {'Content-Type': DataType.JSON.toString()},
-      JSON.stringify(putData),
-    );
+      path: '/url/path/123',
+      headers: {'Content-Type': DataType.JSON.toString()},
+      data: JSON.stringify(putData),
+    });
   });
 
   it('can make DELETE request', async () => {
@@ -208,7 +214,7 @@ describe('HTTP client', () => {
     fetchMock.mockResponseOnce(buildMockResponse(successResponse));
 
     await expect(client.delete({path: '/url/path/123'})).resolves.toEqual(buildExpectedResponse(successResponse));
-    assertHttpRequest('DELETE', domain, '/url/path/123');
+    assertHttpRequest({method: 'DELETE', domain, path: '/url/path/123'});
   });
 
   it('gracefully handles errors', async () => {
@@ -234,7 +240,7 @@ describe('HTTP client', () => {
           expect(error.message).toContain(requestId);
         }
 
-        assertHttpRequest('GET', domain, '/url/path');
+        assertHttpRequest({method: 'GET', domain, path: '/url/path'});
       });
 
       expect(caught).toEqual(true);
@@ -274,7 +280,7 @@ describe('HTTP client', () => {
     await expect(client.get({path: '/url/path', extraHeaders: customHeaders})).resolves.toEqual(
       buildExpectedResponse(successResponse),
     );
-    assertHttpRequest('GET', domain, '/url/path', customHeaders);
+    assertHttpRequest({method: 'GET', domain, path: '/url/path', headers: customHeaders});
   });
 
   it('extends User-Agent if it is provided', async () => {
@@ -286,8 +292,13 @@ describe('HTTP client', () => {
     await expect(client.get({path: '/url/path', extraHeaders: customHeaders})).resolves.toEqual(
       buildExpectedResponse(successResponse),
     );
-    assertHttpRequest('GET', domain, '/url/path', {
-      'User-Agent': expect.stringContaining('My agent | Shopify App Dev Kit v'),
+    assertHttpRequest({
+      method: 'GET',
+      domain,
+      path: '/url/path',
+      headers: {
+        'User-Agent': expect.stringContaining('My agent | Shopify App Dev Kit v'),
+      },
     });
 
     customHeaders = {'user-agent': 'My lowercase agent'};
@@ -297,8 +308,13 @@ describe('HTTP client', () => {
     await expect(client.get({path: '/url/path', extraHeaders: customHeaders})).resolves.toEqual(
       buildExpectedResponse(successResponse),
     );
-    assertHttpRequest('GET', domain, '/url/path', {
-      'User-Agent': expect.stringContaining('My lowercase agent | Shopify App Dev Kit v'),
+    assertHttpRequest({
+      method: 'GET',
+      domain,
+      path: '/url/path',
+      headers: {
+        'User-Agent': expect.stringContaining('My lowercase agent | Shopify App Dev Kit v'),
+      },
     });
   });
 
@@ -321,7 +337,7 @@ describe('HTTP client', () => {
     );
 
     await expect(client.get({path: '/url/path', tries: 3})).resolves.toEqual(buildExpectedResponse(successResponse));
-    assertHttpRequest('GET', domain, '/url/path', {}, null, 3);
+    assertHttpRequest({method: 'GET', domain, path: '/url/path', tries: 3});
   });
 
   it('retries failed requests and stops on non-retriable errors', async () => {
@@ -336,7 +352,7 @@ describe('HTTP client', () => {
 
     await expect(client.get({path: '/url/path', tries: 3})).rejects.toBeInstanceOf(ShopifyErrors.HttpResponseError);
     // The second call resulted in a non-retriable error
-    assertHttpRequest('GET', domain, '/url/path', {}, null, 2);
+    assertHttpRequest({method: 'GET', domain, path: '/url/path', tries: 2});
   });
 
   it('stops retrying after reaching the limit', async () => {
@@ -351,7 +367,7 @@ describe('HTTP client', () => {
     );
 
     await expect(client.get({path: '/url/path', tries: 3})).rejects.toBeInstanceOf(ShopifyErrors.HttpMaxRetriesError);
-    assertHttpRequest('GET', domain, '/url/path', {}, null, 3);
+    assertHttpRequest({method: 'GET', domain, path: '/url/path', tries: 3});
   });
 
   it('waits for the amount of time defined by the Retry-After header', async () => {
@@ -375,7 +391,7 @@ describe('HTTP client', () => {
     }, 4000);
 
     await expect(client.get({path: '/url/path', tries: 2})).resolves.toEqual(buildExpectedResponse(successResponse));
-    assertHttpRequest('GET', domain, '/url/path', {}, null, 2);
+    assertHttpRequest({method: 'GET', domain, path: '/url/path', tries: 2});
     clearTimeout(retryTimeout);
   });
 });

--- a/src/clients/http_client/test/test_helper.ts
+++ b/src/clients/http_client/test/test_helper.ts
@@ -5,14 +5,23 @@ beforeEach(() => {
   currentCall = 0;
 });
 
-export function assertHttpRequest(
-  method: string,
-  domain: string,
-  path: string,
-  headers: Record<string, unknown> = {},
-  data: string | null = null,
+interface AssertHttpRequestParams {
+  method: string;
+  domain: string;
+  path: string;
+  headers?: Record<string, unknown>;
+  data?: string | null;
+  tries?: number;
+}
+
+export function assertHttpRequest({
+  method,
+  domain,
+  path,
+  headers = {},
+  data = null,
   tries = 1,
-): void {
+}: AssertHttpRequestParams): void {
   const maxCall = currentCall + tries;
   for (let i = currentCall; i < maxCall; i++) {
     currentCall++;

--- a/src/clients/rest/rest_client.ts
+++ b/src/clients/rest/rest_client.ts
@@ -4,22 +4,26 @@ import {Context} from '../../context';
 import {ShopifyHeader} from '../../base_types';
 import {HttpClient} from '../http_client/http_client';
 import {RequestParams, GetRequestParams} from '../http_client/types';
+import * as ShopifyErrors from '../../error';
 
 import {RestRequestReturn, PageInfo} from './types';
 
 class RestClient extends HttpClient {
   private static LINK_HEADER_REGEXP = /<([^<]+)>; rel="([^"]+)"/;
 
-  private accessToken: string;
-
-  public constructor(domain: string, accessToken: string) {
+  public constructor(domain: string, readonly accessToken?: string) {
     super(domain);
-    this.accessToken = accessToken;
+
+    if (!Context.IS_PRIVATE_APP && !accessToken) {
+      throw new ShopifyErrors.MissingRequiredArgument('Missing access token when creating REST client');
+    }
   }
 
   protected async request(params: RequestParams): Promise<RestRequestReturn> {
     params.extraHeaders = {...params.extraHeaders};
-    params.extraHeaders[ShopifyHeader.AccessToken] = this.accessToken;
+
+    params.extraHeaders[ShopifyHeader.AccessToken] = Context.IS_PRIVATE_APP
+      ? Context.API_SECRET_KEY : this.accessToken as string;
 
     params.path = this.getRestPath(params.path);
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -16,6 +16,11 @@ interface ContextInterface extends ContextParams {
    * Throws error if context has not been initialized.
    */
   throwIfUninitialized(): void | never;
+
+  /**
+   * Throws error if the current app is private.
+   */
+  throwIfPrivateApp(message: string): void | never;
 }
 
 const Context: ContextInterface = {
@@ -25,6 +30,7 @@ const Context: ContextInterface = {
   HOST_NAME: '',
   API_VERSION: ApiVersion.Unstable,
   IS_EMBEDDED_APP: true,
+  IS_PRIVATE_APP: false,
   SESSION_STORAGE: new MemorySessionStorage(),
 
   initialize(params: ContextParams): void {
@@ -55,6 +61,7 @@ const Context: ContextInterface = {
     this.HOST_NAME = params.HOST_NAME;
     this.API_VERSION = params.API_VERSION;
     this.IS_EMBEDDED_APP = params.IS_EMBEDDED_APP;
+    this.IS_PRIVATE_APP = params.IS_PRIVATE_APP;
 
     if (params.SESSION_STORAGE) {
       this.SESSION_STORAGE = params.SESSION_STORAGE;
@@ -66,6 +73,12 @@ const Context: ContextInterface = {
       throw new ShopifyErrors.UninitializedContextError(
         'Context has not been properly initialized. Please call the .initialize() method to setup your app context object.',
       );
+    }
+  },
+
+  throwIfPrivateApp(message: string): void {
+    if (Context.IS_PRIVATE_APP) {
+      throw new ShopifyErrors.PrivateAppError(message);
     }
   },
 };

--- a/src/error.ts
+++ b/src/error.ts
@@ -12,6 +12,7 @@ class MissingJwtTokenError extends ShopifyError {}
 
 class SafeCompareError extends ShopifyError {}
 class UninitializedContextError extends ShopifyError {}
+class PrivateAppError extends ShopifyError {}
 
 class HttpRequestError extends ShopifyError {}
 class HttpMaxRetriesError extends ShopifyError {}
@@ -59,4 +60,5 @@ export {
   MissingRequiredArgument,
   UnsupportedClientType,
   SessionStorageError,
+  PrivateAppError,
 };

--- a/src/test/context.test.ts
+++ b/src/test/context.test.ts
@@ -15,6 +15,7 @@ const validParams: ContextParams = {
   HOST_NAME: 'host_name',
   API_VERSION: ApiVersion.Unstable,
   IS_EMBEDDED_APP: true,
+  IS_PRIVATE_APP: false,
 };
 
 const originalWarn = console.warn;

--- a/src/test/test_helper.ts
+++ b/src/test/test_helper.ts
@@ -15,6 +15,7 @@ beforeEach(() => {
     HOST_NAME: 'test_host_name',
     API_VERSION: ApiVersion.Unstable,
     IS_EMBEDDED_APP: false,
+    IS_PRIVATE_APP: false,
     SESSION_STORAGE: new MemorySessionStorage(),
   });
 

--- a/src/webhooks/test/registry.test.ts
+++ b/src/webhooks/test/registry.test.ts
@@ -460,27 +460,27 @@ function createWebhookQuery(topic: string, address: string, deliveryMethod?: Del
 }
 
 function assertWebhookCheckRequest(webhook: RegisterOptions) {
-  assertHttpRequest(
-    Method.Post.toString(),
-    webhook.shop,
-    `/admin/api/${Context.API_VERSION}/graphql.json`,
-    {
+  assertHttpRequest({
+    method: Method.Post.toString(),
+    domain: webhook.shop,
+    path: `/admin/api/${Context.API_VERSION}/graphql.json`,
+    headers: {
       [Header.ContentType]: DataType.GraphQL.toString(),
       [ShopifyHeader.AccessToken]: webhook.accessToken,
     },
-    createWebhookCheckQuery(webhook.topic),
-  );
+    data: createWebhookCheckQuery(webhook.topic),
+  });
 }
 
 function assertWebhookRegistrationRequest(webhook: RegisterOptions, webhookId?: string) {
-  assertHttpRequest(
-    Method.Post.toString(),
-    webhook.shop,
-    `/admin/api/${Context.API_VERSION}/graphql.json`,
-    {
+  assertHttpRequest({
+    method: Method.Post.toString(),
+    domain: webhook.shop,
+    path: `/admin/api/${Context.API_VERSION}/graphql.json`,
+    headers: {
       [Header.ContentType]: DataType.GraphQL.toString(),
       [ShopifyHeader.AccessToken]: webhook.accessToken,
     },
-    createWebhookQuery(webhook.topic, `https://${Context.HOST_NAME}${webhook.path}`, webhook.deliveryMethod, webhookId),
-  );
+    data: createWebhookQuery(webhook.topic, `https://${Context.HOST_NAME}${webhook.path}`, webhook.deliveryMethod, webhookId),
+  });
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, both the GraphQL and REST clients require an access token when created, which works for public / custom apps, but not for private ones since they don't go through OAuth. This PR aims to solve that problem by adding a setting to the library to indicate that the current app is a private one.

### WHAT is this pull request doing?

If the app is private, the clients will automatically switch over to using the app's password as the access token, rather than the one obtained in the constructor. That way, callers just need to know the shop for which they're making requests and the library handles the logic of which value to send as the access token header.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)