### PR TITLE
Set OAuth cookies SameSite to lax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Webhooks types are now exported outside the library [#91](https://github.com/shopify/shopify-node-api/pull/91)
 ### Fixed
 - Use cryptographically random bytes to generate nonce [#98](https://github.com/Shopify/shopify-node-api/pull/98)
+- Stop using `SameSite=none` cookies for OAuth, using `lax` instead [#100](https://github.com/Shopify/shopify-node-api/pull/100)
 
 ## [0.3.1] - 2021-02-03
 ### Fixed

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -63,7 +63,7 @@ const ShopifyOAuth = {
     cookies.set(ShopifyOAuth.SESSION_COOKIE_NAME, session.id, {
       signed: true,
       expires: new Date(Date.now() + 60000),
-      sameSite: 'none',
+      sameSite: 'lax',
       secure: true,
     });
 
@@ -173,7 +173,7 @@ const ShopifyOAuth = {
     cookies.set(ShopifyOAuth.SESSION_COOKIE_NAME, currentSession.id, {
       signed: true,
       expires: oauthSessionExpiration,
-      sameSite: 'none',
+      sameSite: 'lax',
       secure: true,
     });
 


### PR DESCRIPTION
### WHY are these changes introduced?

We no longer use 3rd party cookies in any part of apps built using the library, so we don't need to support cross-site requests. That allows us to stop setting our OAuth cookie's `SameSite` value to `none`.

### WHAT is this pull request doing?

Setting `SameSite=lax` in the OAuth cookie.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
