### PR TITLE
Handle request body objects in GraphQL proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- GraphQL Proxy attempts to parse the request body as JSON before passing it to the client. [#106](https://github.com/shopify/shopify-node-api/pull/106)
+
 ## [0.4.0] - 2021-02-10
 
 ### Added

--- a/src/utils/test/graphql_proxy.test.ts
+++ b/src/utils/test/graphql_proxy.test.ts
@@ -23,6 +23,18 @@ const shopQuery = `{
     name
   }
 }`;
+const objectQuery = {
+  query: `{
+    query {
+      with {
+        variable
+      }
+    }
+  }`,
+  variables: `{
+    foo: bar
+  }`,
+};
 const shop = 'shop.myshopify.com';
 const accessToken = 'dangit';
 let token = '';
@@ -54,14 +66,23 @@ describe('GraphQL proxy with session', () => {
     const app = express();
     app.post('/proxy', graphqlProxy);
 
-    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
-    const response = await request(app)
+    fetchMock.mockResponses(JSON.stringify(successResponse), JSON.stringify(successResponse));
+
+    const firstResponse = await request(app)
       .post('/proxy')
       .set('authorization', `Bearer ${token}`)
       .send(shopQuery)
       .expect(200);
 
-    expect(JSON.parse(response.text)).toEqual(successResponse);
+    expect(JSON.parse(firstResponse.text)).toEqual(successResponse);
+
+    const nextResponse = await request(app)
+      .post('/proxy')
+      .set('authorization', `Bearer ${token}`)
+      .send(objectQuery)
+      .expect(200);
+
+    expect(JSON.parse(nextResponse.text)).toEqual(successResponse);
   });
 
   it('rejects if no query', async () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The GraphQL Proxy was always passing the request body as a string, but in the case where there is a variable passed, the body will be JSON. 

### WHAT is this pull request doing?

Updates GraphQL Proxy to attempt to parse the incoming request body. If it's able to parse an object, that object will be passed to the client. Otherwise, it will pass the received string. 

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
