### PR TITLE
Put emphasis on having .env in gitignore + add resource to rotate credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Webhooks types are now exported outside the library [#91](https://github.com/shopify/shopify-node-api/pull/91)
 - Added support for private apps [#99](https://github.com/Shopify/shopify-node-api/pull/99)
 - `USER_AGENT_PREFIX` added to Context, to add agent to all requests [#101](https://github.com/Shopify/shopify-node-api/pull/101)
+- Add link to tutorial on how to rotate credentials if neccesary [#107](https://github.com/Shopify/shopify-node-api/pull/107)
 
 ### Fixed
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -45,12 +45,15 @@ src/
   index.ts
 ```
 
-If your application is in a Git repository, you should make sure to add these files to `.gitignore`:
+If your application is in a Git repository, you should **make sure to add these files to `.gitignore`**.
+
 ```
 .env
 dist
 node_modules
 ```
+
+ **Important:** If you ever accidentally commit your API secret to GitHub or any other third party, you can follow [this tutorial](https://shopify.dev/tutorials/rotate-revoke-api-credentials) on how to generate new credentials for your application.
 
 `tsconfig.json`
 ```json


### PR DESCRIPTION
### WHY are these changes introduced?
We've noticed in the past that app developers will mistakenly commit credentials to GitHub. This revises the doc to put more emphasis on the importance of not missing this step to prevent that, as well as add a link to how they can rotate their credentials.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
