### PR TITLE
Adding AuthScopes value object

### DIFF
--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -71,7 +71,7 @@ const ShopifyOAuth = {
     /* eslint-disable @typescript-eslint/naming-convention */
     const query = {
       client_id: Context.API_KEY,
-      scope: Context.SCOPES.join(', '),
+      scope: Context.SCOPES.toString(),
       redirect_uri: `https://${Context.HOST_NAME}${redirectPath}`,
       state,
       'grant_options[]': isOnline ? 'per-user' : '',

--- a/src/auth/oauth/test/oauth.test.ts
+++ b/src/auth/oauth/test/oauth.test.ts
@@ -92,7 +92,7 @@ describe('beginAuth', () => {
     /* eslint-disable @typescript-eslint/naming-convention */
     const query = {
       client_id: Context.API_KEY,
-      scope: Context.SCOPES,
+      scope: Context.SCOPES.toString(),
       redirect_uri: `https://${Context.HOST_NAME}/some-callback`,
       state: session ? session.state : '',
       'grant_options[]': '',
@@ -111,7 +111,7 @@ describe('beginAuth', () => {
     /* eslint-disable @typescript-eslint/naming-convention */
     const query = {
       client_id: Context.API_KEY,
-      scope: Context.SCOPES,
+      scope: Context.SCOPES.toString(),
       redirect_uri: `https://${Context.HOST_NAME}/some-callback`,
       state: session ? session.state : '',
       'grant_options[]': 'per-user',
@@ -221,7 +221,7 @@ describe('validateAuthCallback', () => {
     /* eslint-disable @typescript-eslint/naming-convention */
     const successResponse = {
       access_token: 'some access token string',
-      scope: Context.SCOPES.join(','),
+      scope: Context.SCOPES.toString(),
     };
     /* eslint-enable @typescript-eslint/naming-convention */
 
@@ -255,7 +255,7 @@ describe('validateAuthCallback', () => {
     /* eslint-disable @typescript-eslint/naming-convention */
     const successResponse = {
       access_token: 'some access token string',
-      scope: Context.SCOPES.join(','),
+      scope: Context.SCOPES.toString(),
     };
     /* eslint-enable @typescript-eslint/naming-convention */
 

--- a/src/auth/scopes/index.ts
+++ b/src/auth/scopes/index.ts
@@ -1,0 +1,73 @@
+class AuthScopes {
+  public static SCOPE_DELIMITER = ',';
+
+  private compressedScopes: Set<string>;
+  private expandedScopes: Set<string>;
+
+  constructor(scopes: string | string[]) {
+    let scopesArray: string[] = [];
+    if (typeof scopes === 'string') {
+      scopesArray = scopes.split(new RegExp(`${AuthScopes.SCOPE_DELIMITER}\\s*`));
+    } else {
+      scopesArray = scopes;
+    }
+
+    scopesArray = scopesArray.map((scope) => scope.trim()).filter((scope) => scope.length);
+
+    const impliedScopes = this.getImpliedScopes(scopesArray);
+
+    const scopeSet = new Set(scopesArray);
+    const impliedSet = new Set(impliedScopes);
+
+    this.compressedScopes = new Set([...scopeSet].filter((x) => !impliedSet.has(x)));
+    this.expandedScopes = new Set([...scopeSet, ...impliedSet]);
+  }
+
+  public has(scope: string | string[] | AuthScopes) {
+    let other: AuthScopes;
+
+    if (scope instanceof AuthScopes) {
+      other = scope;
+    } else {
+      other = new AuthScopes(scope);
+    }
+
+    return other.toArray().filter((x) => !this.expandedScopes.has(x)).length === 0;
+  }
+
+  public equals(otherScopes: string | string[] | AuthScopes) {
+    let other: AuthScopes;
+
+    if (otherScopes instanceof AuthScopes) {
+      other = otherScopes;
+    } else {
+      other = new AuthScopes(otherScopes);
+    }
+
+    return (
+      this.compressedScopes.size === other.compressedScopes.size &&
+      this.toArray().filter((x) => !other.has(x)).length === 0
+    );
+  }
+
+  public toString() {
+    return this.toArray().join(AuthScopes.SCOPE_DELIMITER);
+  }
+
+  public toArray() {
+    return [...this.compressedScopes];
+  }
+
+  private getImpliedScopes(scopesArray: string[]): string[] {
+    return scopesArray.reduce((array: string[], current: string) => {
+      const matches = current.match(/^(unauthenticated_)?write_(.*)$/);
+      if (matches) {
+        array.push(`${matches[1] ? matches[1] : ''}read_${matches[2]}`);
+      }
+
+      return array;
+    }, []);
+  }
+}
+
+export {AuthScopes};

--- a/src/auth/scopes/test/scopes.test.ts
+++ b/src/auth/scopes/test/scopes.test.ts
@@ -1,0 +1,138 @@
+import '../../../test/test_helper';
+
+import {AuthScopes} from '../index';
+
+describe('AuthScopes', () => {
+  it('can parse and trim string scopes', () => {
+    const scopeString = ' read_products, read_orders,,write_customers ';
+    const scopes = new AuthScopes(scopeString);
+
+    expect(scopes.toString()).toEqual('read_products,read_orders,write_customers');
+  });
+
+  it('can parse and trim array scopes', () => {
+    const scopeString = [' read_products', 'read_orders', '', 'unauthenticated_write_customers '];
+    const scopes = new AuthScopes(scopeString);
+
+    expect(scopes.toString()).toEqual('read_products,read_orders,unauthenticated_write_customers');
+  });
+
+  it('trims implied scopes', () => {
+    const scopeString = 'read_customers,write_customers,read_products';
+    const scopes = new AuthScopes(scopeString);
+
+    expect(scopes.toString()).toEqual('write_customers,read_products');
+  });
+
+  it('trims implied unauthenticated scopes', () => {
+    const scopeString = 'unauthenticated_read_customers,unauthenticated_write_customers,unauthenticated_read_products';
+    const scopes = new AuthScopes(scopeString);
+
+    expect(scopes.toString()).toEqual('unauthenticated_write_customers,unauthenticated_read_products');
+  });
+});
+
+describe('AuthScopes.equals', () => {
+  it('returns true for equivalent sets', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products');
+    const scopes2 = new AuthScopes(['write_customers', 'read_products']);
+
+    expect(scopes1.equals(scopes2)).toBeTruthy();
+    expect(scopes2.equals(scopes1)).toBeTruthy();
+  });
+
+  it('returns false for different sets', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products');
+    const scopes2 = new AuthScopes(['write_customers', 'write_orders']);
+
+    expect(scopes1.equals(scopes2)).toBeFalsy();
+    expect(scopes2.equals(scopes1)).toBeFalsy();
+  });
+
+  it('returns true if there are implied scopes', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products,write_products');
+    const scopes2 = new AuthScopes(['write_customers', 'write_products']);
+
+    expect(scopes1.equals(scopes2)).toBeTruthy();
+    expect(scopes2.equals(scopes1)).toBeTruthy();
+  });
+
+  it('returns false if current set is a subset of other', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products,write_products');
+    const scopes2 = new AuthScopes(['write_customers', 'write_products', 'write_orders']);
+
+    expect(scopes1.equals(scopes2)).toBeFalsy();
+    expect(scopes2.equals(scopes1)).toBeFalsy();
+  });
+
+  it('allows comparing against strings', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products,write_products');
+
+    expect(scopes1.equals('write_customers,read_products,write_products')).toBeTruthy();
+  });
+
+  it('allows comparing against string arrays', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products,write_products');
+
+    expect(scopes1.equals(['write_customers', 'read_products', 'write_products'])).toBeTruthy();
+  });
+});
+
+describe('AuthScopes.has', () => {
+  it('returns true for subset string', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products');
+
+    expect(scopes1.has('write_customers')).toBeTruthy();
+  });
+
+  it('returns true for subset string array', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products');
+
+    expect(scopes1.has(['write_customers'])).toBeTruthy();
+  });
+
+  it('returns true for subset scopes object', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products');
+    const scopes2 = new AuthScopes(['write_customers']);
+
+    expect(scopes1.has(scopes2)).toBeTruthy();
+  });
+
+  it('returns true for equal string', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products');
+
+    expect(scopes1.has('write_customers,read_products')).toBeTruthy();
+  });
+
+  it('returns true for equal string array', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products');
+
+    expect(scopes1.has(['write_customers', 'read_products'])).toBeTruthy();
+  });
+
+  it('returns true for equal scopes object', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products');
+    const scopes2 = new AuthScopes(['write_customers', 'read_products']);
+
+    expect(scopes1.has(scopes2)).toBeTruthy();
+  });
+
+  it('returns false for superset string', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products');
+
+    expect(scopes1.has('write_customers,read_products,read_orders')).toBeFalsy();
+  });
+
+  it('returns false for superset string array', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products');
+
+    expect(scopes1.has(['write_customers', 'read_products', 'read_orders'])).toBeFalsy();
+  });
+
+  it('returns false for superset scopes object', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products');
+    const scopes2 = new AuthScopes(['write_customers', 'read_products', 'read_orders']);
+
+    expect(scopes1.has(scopes2)).toBeFalsy();
+  });
+});

--- a/src/base_types.ts
+++ b/src/base_types.ts
@@ -1,9 +1,10 @@
 import {SessionStorage} from './auth/session';
+import {AuthScopes} from './auth/scopes';
 
 export interface ContextParams {
   API_KEY: string;
   API_SECRET_KEY: string;
-  SCOPES: string[];
+  SCOPES: string[] | AuthScopes;
   HOST_NAME: string;
   API_VERSION: ApiVersion;
   IS_EMBEDDED_APP: boolean;

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,9 +1,11 @@
 import * as ShopifyErrors from './error';
 import {SessionStorage, MemorySessionStorage} from './auth/session';
 import {ApiVersion, ContextParams} from './base_types';
+import {AuthScopes} from './auth/scopes';
 
 interface ContextInterface extends ContextParams {
   SESSION_STORAGE: SessionStorage;
+  SCOPES: AuthScopes;
 
   /**
    * Sets up the Shopify API Library to be able to integrate with Shopify and run authenticated commands.
@@ -26,7 +28,7 @@ interface ContextInterface extends ContextParams {
 const Context: ContextInterface = {
   API_KEY: '',
   API_SECRET_KEY: '',
-  SCOPES: [],
+  SCOPES: new AuthScopes([]),
   HOST_NAME: '',
   API_VERSION: ApiVersion.Unstable,
   IS_EMBEDDED_APP: true,
@@ -34,6 +36,13 @@ const Context: ContextInterface = {
   SESSION_STORAGE: new MemorySessionStorage(),
 
   initialize(params: ContextParams): void {
+    let scopes: AuthScopes;
+    if (params.SCOPES instanceof AuthScopes) {
+      scopes = params.SCOPES;
+    } else {
+      scopes = new AuthScopes(params.SCOPES);
+    }
+
     // Make sure that the essential params actually have content in them
     const missing: string[] = [];
     if (!params.API_KEY.length) {
@@ -42,7 +51,7 @@ const Context: ContextInterface = {
     if (!params.API_SECRET_KEY.length) {
       missing.push('API_SECRET_KEY');
     }
-    if (!params.SCOPES.length) {
+    if (!scopes.toArray().length) {
       missing.push('SCOPES');
     }
     if (!params.HOST_NAME.length) {
@@ -57,7 +66,7 @@ const Context: ContextInterface = {
 
     this.API_KEY = params.API_KEY;
     this.API_SECRET_KEY = params.API_SECRET_KEY;
-    this.SCOPES = params.SCOPES;
+    this.SCOPES = scopes;
     this.HOST_NAME = params.HOST_NAME;
     this.API_VERSION = params.API_VERSION;
     this.IS_EMBEDDED_APP = params.IS_EMBEDDED_APP;

--- a/src/test/context.test.ts
+++ b/src/test/context.test.ts
@@ -32,7 +32,7 @@ describe('Context object', () => {
 
     expect(Context.API_KEY).toEqual(validParams.API_KEY);
     expect(Context.API_SECRET_KEY).toEqual(validParams.API_SECRET_KEY);
-    expect(Context.SCOPES).toEqual(validParams.SCOPES);
+    expect(Context.SCOPES.equals(validParams.SCOPES)).toBeTruthy();
     expect(Context.HOST_NAME).toEqual(validParams.HOST_NAME);
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

We need to add the ability to tell whether an app's scopes have changed to the library. We've recently done that for `shopify_api` by adding a value object to hold the scopes instead of an array / string.

### WHAT is this pull request doing?

Creating a new `AuthScopes` value object, which abstracts implied scopes and allows to easily compare two sets of scopes.

It also changes the type of `Context.SCOPES` to be `AuthScopes`, which enables apps to easily compare if a session has different scopes than the current ones:

```ts
if (!Shopify.Context.SCOPES.equals(session.scope)) {
  console.log('Different scopes!!!');
}
```

cc @rezaansyed and @NabeelAhsen - I basically ripped off the logic from `shopify_api` here!

Next up:
- Change `koa-shopify-auth`'s `verifyRequest` middleware to trigger OAuth if the current session's scopes no longer equal the app's current scopes