### PR TITLE
Add January 2021 API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 - Minor text/doc changes
+- Added `2021-01` API version to enum. [#117](https://github.com/shopify/shopify-node-api/pull/117)
+
 ## [1.0.0]
 
 - Initial public release

--- a/src/base_types.ts
+++ b/src/base_types.ts
@@ -22,6 +22,7 @@ export enum ApiVersion {
   April20 = '2020-04',
   July20 = '2020-07',
   October20 = '2020-10',
+  January21 = '2021-01',
   Unstable = 'unstable',
   Unversioned = 'unversioned',
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #116 

The `2021-01` API version was missing from the version options.

### WHAT is this pull request doing?

Adding the missing version.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
- [X] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
