### PR TITLE
Allow loading offline sessions from loadCurrentSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 - Minor text/doc changes
 - Added `2021-01` API version to enum. [#117](https://github.com/shopify/shopify-node-api/pull/117)
+- Allow retrieving offline sessions using `loadCurrentSession`. [#119](https://github.com/shopify/shopify-node-api/pull/119)
 
 ## [1.0.0]
 

--- a/docs/usage/oauth.md
+++ b/docs/usage/oauth.md
@@ -112,16 +112,16 @@ You can use the `Shopify.Utils.loadCurrentSession()` method to load an online se
 
 As mentioned in the previous sections, you can use the OAuth methods to create both offline and online sessions. Once the process is completed, the session will be stored as per your `Context.SESSION_STORAGE` strategy, and can be retrieved with the below utitilies.
 
-- To load an online session:
+- To load a session, you can use the following method. You can load both online and offline sessions from the current request / response objects.
 ```ts
-await Shopify.Utils.loadCurrentSession(request, response)
+await Shopify.Utils.loadCurrentSession(request, response, isOnline);
 ```
-- To load an offline session:
+- If you need to load a session for a background job, you can get offline sessions directly from the shop.
 ```ts
-await Shopify.Utils.loadOfflineSession(shop)
+await Shopify.Utils.loadOfflineSession(shop);
 ```
 
-The library supports creating both offline and online sessions for the same shop, so it is up to the app to call the appropriate loading method depending on its needs.
+**Note**: the `loadOfflineSession` method does not perform any validations on the `shop` parameter. You should avoid calling it from user inputs or URLs.
 
 ## Detecting scope changes
 

--- a/src/utils/delete-current-session.ts
+++ b/src/utils/delete-current-session.ts
@@ -7,16 +7,18 @@ import * as ShopifyErrors from '../error';
 /**
  * Finds and deletes the current user's session, based on the given request and response
  *
- * @param req Current HTTP request
- * @param res Current HTTP response
+ * @param request  Current HTTP request
+ * @param response Current HTTP response
+ * @param isOnline Whether to load online (default) or offline sessions (optional)
  */
 export default async function deleteCurrentSession(
   request: http.IncomingMessage,
   response: http.ServerResponse,
+  isOnline = true,
 ): Promise<boolean | never> {
   Context.throwIfUninitialized();
 
-  const sessionId = ShopifyOAuth.getCurrentSessionId(request, response);
+  const sessionId = ShopifyOAuth.getCurrentSessionId(request, response, isOnline);
   if (!sessionId) {
     throw new ShopifyErrors.SessionNotFound('No active session found.');
   }

--- a/src/utils/load-current-session.ts
+++ b/src/utils/load-current-session.ts
@@ -7,16 +7,18 @@ import {Session} from '../auth/session';
 /**
  * Loads the current user's session, based on the given request and response.
  *
- * @param req Current HTTP request
- * @param res Current HTTP response
+ * @param request  Current HTTP request
+ * @param response Current HTTP response
+ * @param isOnline Whether to load online (default) or offline sessions (optional)
  */
 export default async function loadCurrentSession(
   request: http.IncomingMessage,
   response: http.ServerResponse,
+  isOnline = true,
 ): Promise<Session | undefined> {
   Context.throwIfUninitialized();
 
-  const sessionId = ShopifyOAuth.getCurrentSessionId(request, response);
+  const sessionId = ShopifyOAuth.getCurrentSessionId(request, response, isOnline);
   if (!sessionId) {
     return Promise.resolve(undefined);
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, the `loadCurrentSession` method doesn't allow loading offline sessions from the request, which is desired for some apps.

### WHAT is this pull request doing?

Adding an optional parameter (defaulting to online) to allow returning offline sessions as well as online ones.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
- [X] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
