### PR TITLE
Run CI checks on both PRs and pushes

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-on: push
+on: [ push, pull_request ]
 name: CI
 jobs:
   CI:


### PR DESCRIPTION
### WHY are these changes introduced?

We are currently not running CI checks on PRs from forks, which makes it harder to spot errors before we merge them.

### WHAT is this pull request doing?

Running the CI workflow on both PRs and pushes so we can cover external contributions as well.

## Checklist

- [ ] ~I have added a changelog entry, prefixed by the type of change noted above~
- [ ] ~I have added/updated tests for this change~
- [ ] ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~
