### PR TITLE
Allow plain objects in Custom `loadSession` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+### Fixed
+
+- Allow plain objects to be returned from the `loadCallback` on `CustomSessionStorage` [#126](https://github.com/shopify/shopify-node-api/pull/126)
+
 ## [1.1.0] - 2021-03-02
+
 - Minor text/doc changes
 - Added `2021-01` API version to enum. [#117](https://github.com/shopify/shopify-node-api/pull/117)
 - Allow retrieving offline sessions using `loadCurrentSession`. [#119](https://github.com/shopify/shopify-node-api/pull/119)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 ### Added
+- Allow plain objects to be returned from the `loadCallback` on `CustomSessionStorage` [#126](https://github.com/shopify/shopify-node-api/pull/126)
 
 ### Fixed
 
-- Allow plain objects to be returned from the `loadCallback` on `CustomSessionStorage` [#126](https://github.com/shopify/shopify-node-api/pull/126)
 
 ## [1.1.0] - 2021-03-02
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -11,12 +11,13 @@ Before you start writing your application, please note that the Shopify library 
 - Create a new instance of `CustomSessionStorage`, passing in callbacks to store, load, and delete sessions.
 - Implement those callbacks so that they perform the necessary actions in your preferred storage method.
 - Provide that instance when calling `Shopify.Context.initialize`, for example:
+
 ```ts
   // src/my_session_storage.ts
   import { SessionStorage } from '@shopify/shopify-api';
 
   async function storeCallback(session: Session): Promise<boolean> { ... }
-  async function loadCallback(id: string): Promise<Session | undefined> { ... }
+  async function loadCallback(id: string): Promise<Session | Record<string, unknown> | undefined> { ... }
   async function deleteCallback(id: string): Promise<boolean> { ... }
 
   const mySessionStorage = new Shopify.Session.CustomSessionStorage(

--- a/src/auth/session/storage/custom.ts
+++ b/src/auth/session/storage/custom.ts
@@ -37,7 +37,7 @@ export class CustomSessionStorage implements SessionStorage {
         return result;
       } else if (result instanceof Object && 'id' in result) {
         let session = new Session(result.id as string);
-        session = Object.assign(session, result);
+        session = {...session, ...result};
         return session;
       } else {
         throw new ShopifyErrors.SessionStorageError(

--- a/src/auth/session/storage/custom.ts
+++ b/src/auth/session/storage/custom.ts
@@ -5,7 +5,7 @@ import * as ShopifyErrors from '../../../error';
 export class CustomSessionStorage implements SessionStorage {
   constructor(
     readonly storeCallback: (session: Session) => Promise<boolean>,
-    readonly loadCallback: (id: string) => Promise<Session | undefined>,
+    readonly loadCallback: (id: string) => Promise<Session | Record<string, unknown> | undefined>,
     readonly deleteCallback: (id: string) => Promise<boolean>,
   ) {
     this.storeCallback = storeCallback;
@@ -24,7 +24,7 @@ export class CustomSessionStorage implements SessionStorage {
   }
 
   public async loadSession(id: string): Promise<Session | undefined> {
-    let result: Session | undefined;
+    let result: Session | Record<string, unknown> | undefined;
     try {
       result = await this.loadCallback(id);
     } catch (error) {
@@ -35,6 +35,10 @@ export class CustomSessionStorage implements SessionStorage {
     if (result) {
       if (result instanceof Session) {
         return result;
+      } else if (result instanceof Object && 'id' in result) {
+        let session = new Session(result.id as string);
+        session = Object.assign(session, result);
+        return session;
       } else {
         throw new ShopifyErrors.SessionStorageError(
           `Expected return to be instanceof Session, but received instanceof ${result!.constructor.name}.`,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Previously, we always expected the return from the `loadCallback` to already be an `instanceof Session`, but this can cause some issues in developing the `loadCallback` method for a custom storage solution, due to having to do some extra object manipulation. 

### WHAT is this pull request doing?

`CustomSessionStorage.loadSession` will now allow the `loadCallback` to return _either_ an `instanceof Session` or a plain object. If a plain object is returned, it will be used to instantiate a `new Session` which will then be returned. 

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
~- [ ] Minor: New feature (non-breaking change which adds functionality)~
~- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)~


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)

_NOTE: I have updated the type on the current `CustomSessionStorage` docs under `issues.md`, but will be adding to and updating this docs for `CustomSessionStorage` more thoroughly in a separate PR._ 
