### PR TITLE
[Proposal] Enable library to query Storefront API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+**Note**: When we next release a major version for this library, we should remove the code for backward compatibility from the REST and GraphQL client constructors.
+
+- Refactored the constructors `Shopify.Clients.Rest` and `Shopify.Clients.Graphql` so they allow querying multiple APIs
 
 ## [1.1.0] - 2021-03-02
 - Minor text/doc changes

--- a/src/base_types.ts
+++ b/src/base_types.ts
@@ -12,6 +12,7 @@ export interface ContextParams {
   SESSION_STORAGE?: SessionStorage;
   LOG_FILE?: string;
   USER_AGENT_PREFIX?: string;
+  PRIVATE_APP_STOREFRONT_ACCESS_TOKEN?: string;
 }
 
 export enum ApiVersion {
@@ -29,6 +30,7 @@ export enum ApiVersion {
 
 export enum ShopifyHeader {
   AccessToken = 'X-Shopify-Access-Token',
+  StorefrontAccessToken = 'X-Shopify-Storefront-Access-Token',
   Hmac = 'X-Shopify-Hmac-Sha256',
   Topic = 'X-Shopify-Topic',
   Domain = 'X-Shopify-Shop-Domain',

--- a/src/clients/graphql/graphql_client.ts
+++ b/src/clients/graphql/graphql_client.ts
@@ -2,20 +2,43 @@ import {MissingRequiredArgument} from '../../error';
 import {Context} from '../../context';
 import {ShopifyHeader} from '../../base_types';
 import {HttpClient} from '../http_client/http_client';
-import {DataType, RequestReturn} from '../http_client/types';
+import {ApiClientParams, ApiClientType, DataType, RequestReturn} from '../http_client/types';
 import * as ShopifyErrors from '../../error';
 
 import {GraphqlParams} from './types';
 
+interface AccessTokenHeader {
+  header: string;
+  value: string;
+}
+
 export class GraphqlClient {
+  readonly apiType: ApiClientType;
+  readonly domain: string;
+  readonly accessToken?: string;
+
   private readonly client: HttpClient;
 
-  constructor(readonly domain: string, readonly token?: string) {
-    if (!Context.IS_PRIVATE_APP && !token) {
-      throw new ShopifyErrors.MissingRequiredArgument('Missing access token when creating GraphQL client');
+  // When we next release a major version for this library, we should remove string as a valid type for params and
+  // remove the accessToken param. Also remove the first block.
+  public constructor(params: ApiClientParams | string, accessToken?: string) {
+    if (typeof params === 'string') {
+      // eslint-disable-next-line no-param-reassign
+      params = {
+        domain: params,
+        accessToken,
+      };
     }
 
+    this.domain = params.domain;
     this.client = new HttpClient(this.domain);
+
+    this.apiType = params.apiType || ApiClientType.Admin;
+    this.accessToken = params.accessToken;
+
+    if (!Context.IS_PRIVATE_APP && !this.accessToken) {
+      throw new ShopifyErrors.MissingRequiredArgument('Missing access token when creating GraphQL client');
+    }
   }
 
   async query(params: GraphqlParams): Promise<RequestReturn> {
@@ -23,11 +46,12 @@ export class GraphqlClient {
       throw new MissingRequiredArgument('Query missing.');
     }
 
+    const accessTokenHeader: AccessTokenHeader = this.getAccessTokenHeaderForApiType();
     params.extraHeaders = {
-      [ShopifyHeader.AccessToken]: Context.IS_PRIVATE_APP ? Context.API_SECRET_KEY : this.token as string,
+      [accessTokenHeader.header]: accessTokenHeader.value,
       ...params.extraHeaders,
     };
-    const path = `/admin/api/${Context.API_VERSION}/graphql.json`;
+    const path = `${this.getBasePathForApiType()}/${Context.API_VERSION}/graphql.json`;
 
     let dataType: DataType.GraphQL | DataType.JSON;
 
@@ -38,5 +62,44 @@ export class GraphqlClient {
     }
 
     return this.client.post({path, type: dataType, ...params});
+  }
+
+  private getBasePathForApiType(): string {
+    switch (this.apiType) {
+      case ApiClientType.Admin:
+        return '/admin/api';
+      case ApiClientType.Storefront:
+        return '/api';
+      default:
+        throw new ShopifyErrors.ShopifyError(`Unsupported GraphQL API client type '${this.apiType}'`);
+    }
+  }
+
+  private getAccessTokenHeaderForApiType(): AccessTokenHeader {
+    let header: string;
+    let value: string | undefined;
+    switch (this.apiType) {
+      case ApiClientType.Admin:
+        header = ShopifyHeader.AccessToken;
+        value = Context.IS_PRIVATE_APP ? Context.API_SECRET_KEY : this.accessToken;
+        break;
+      case ApiClientType.Storefront:
+        header = ShopifyHeader.StorefrontAccessToken;
+        value = Context.IS_PRIVATE_APP ? Context.PRIVATE_APP_STOREFRONT_ACCESS_TOKEN : this.accessToken;
+        break;
+      default:
+        throw new ShopifyErrors.ShopifyError(`Unsupported GraphQL API client type '${this.apiType}'`);
+    }
+
+    if (!value) {
+      throw new ShopifyErrors.ShopifyError(
+        `Could not determine the access token header for API client type '${this.apiType}'`,
+      );
+    }
+
+    return {
+      header,
+      value,
+    };
   }
 }

--- a/src/clients/http_client/types.ts
+++ b/src/clients/http_client/types.ts
@@ -3,6 +3,17 @@ import {Headers} from 'node-fetch';
 
 export type HeaderParams = Record<string, string | number>;
 
+export enum ApiClientType {
+  Admin = 'admin',
+  Storefront = 'storefront',
+}
+
+export interface ApiClientParams {
+  apiType?: ApiClientType;
+  domain: string;
+  accessToken?: string;
+}
+
 export enum DataType {
   JSON = 'application/json', // eslint-disable-line @shopify/typescript/prefer-pascal-case-enums
   GraphQL = 'application/graphql', // eslint-disable-line @shopify/typescript/prefer-pascal-case-enums

--- a/src/clients/rest/rest_client.ts
+++ b/src/clients/rest/rest_client.ts
@@ -3,27 +3,39 @@ import querystring from 'querystring';
 import {Context} from '../../context';
 import {ShopifyHeader} from '../../base_types';
 import {HttpClient} from '../http_client/http_client';
-import {RequestParams, GetRequestParams} from '../http_client/types';
+import {ApiClientParams, ApiClientType, RequestParams, GetRequestParams} from '../http_client/types';
 import * as ShopifyErrors from '../../error';
 
 import {RestRequestReturn, PageInfo} from './types';
 
+interface AccessTokenHeader {
+  header: string;
+  value: string;
+}
+
 class RestClient extends HttpClient {
   private static LINK_HEADER_REGEXP = /<([^<]+)>; rel="([^"]+)"/;
 
-  public constructor(domain: string, readonly accessToken?: string) {
-    super(domain);
+  readonly apiType: ApiClientType;
+  readonly accessToken?: string;
 
-    if (!Context.IS_PRIVATE_APP && !accessToken) {
+  public constructor(params: ApiClientParams) {
+    super(params.domain);
+
+    this.apiType = params.apiType || ApiClientType.Admin;
+    this.accessToken = params.accessToken;
+
+    if (!Context.IS_PRIVATE_APP && !this.accessToken) {
       throw new ShopifyErrors.MissingRequiredArgument('Missing access token when creating REST client');
     }
   }
 
   protected async request(params: RequestParams): Promise<RestRequestReturn> {
-    params.extraHeaders = {...params.extraHeaders};
-
-    params.extraHeaders[ShopifyHeader.AccessToken] = Context.IS_PRIVATE_APP
-      ? Context.API_SECRET_KEY : this.accessToken as string;
+    const accessTokenHeader: AccessTokenHeader = this.getAccessTokenHeaderForApiType();
+    params.extraHeaders = {
+      [accessTokenHeader.header]: accessTokenHeader.value,
+      ...params.extraHeaders,
+    };
 
     params.path = this.getRestPath(params.path);
 
@@ -75,16 +87,51 @@ class RestClient extends HttpClient {
   }
 
   private getRestPath(path: string): string {
-    return `/admin/api/${Context.API_VERSION}/${path}.json`;
+    return `${this.getBasePathForApiType()}/${Context.API_VERSION}/${path}.json`;
   }
 
   private buildRequestParams(newPageUrl: string): GetRequestParams {
+    const pattern = `^${this.getBasePathForApiType()}/[^/]+/(.*).json$`;
+
     const url = new URL(newPageUrl);
-    const path = url.pathname.replace(/^\/admin\/api\/[^/]+\/(.*)\.json$/, '$1');
+    const path = url.pathname.replace(new RegExp(pattern), '$1');
     const query = querystring.decode(url.search.replace(/^\?(.*)/, '$1')) as Record<string, string | number>;
     return {
       path,
       query,
+    };
+  }
+
+  private getBasePathForApiType(): string {
+    switch (this.apiType) {
+      case ApiClientType.Admin:
+        return '/admin/api';
+      default:
+        throw new ShopifyErrors.ShopifyError(`Unsupported REST API client type '${this.apiType}'`);
+    }
+  }
+
+  private getAccessTokenHeaderForApiType(): AccessTokenHeader {
+    let header: string;
+    let value: string | undefined;
+    switch (this.apiType) {
+      case ApiClientType.Admin:
+        header = ShopifyHeader.AccessToken;
+        value = Context.IS_PRIVATE_APP ? Context.API_SECRET_KEY : this.accessToken;
+        break;
+      default:
+        throw new ShopifyErrors.ShopifyError(`Unsupported REST API client type '${this.apiType}'`);
+    }
+
+    if (!value) {
+      throw new ShopifyErrors.ShopifyError(
+        `Could not determine the access token header for API client type '${this.apiType}'`,
+      );
+    }
+
+    return {
+      header,
+      value,
     };
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -83,6 +83,10 @@ const Context: ContextInterface = {
     if (params.LOG_FILE) {
       this.LOG_FILE = params.LOG_FILE;
     }
+
+    if (params.PRIVATE_APP_STOREFRONT_ACCESS_TOKEN) {
+      this.PRIVATE_APP_STOREFRONT_ACCESS_TOKEN = params.PRIVATE_APP_STOREFRONT_ACCESS_TOKEN;
+    }
   },
 
   throwIfUninitialized(): void {

--- a/src/utils/graphql_proxy.ts
+++ b/src/utils/graphql_proxy.ts
@@ -1,5 +1,6 @@
 import http from 'http';
 
+import {ApiClientType} from '../clients/types';
 import {GraphqlClient} from '../clients/graphql';
 import * as ShopifyErrors from '../error';
 
@@ -38,7 +39,11 @@ export default async function graphqlProxy(userReq: http.IncomingMessage, userRe
         const options = {
           data: reqBodyObject ? reqBodyObject : reqBodyString,
         };
-        const client = new GraphqlClient(shopName, token);
+        const client = new GraphqlClient({
+          apiType: ApiClientType.Admin,
+          domain: shopName,
+          accessToken: token,
+        });
         const response = await client.query(options);
         body = response.body;
       } catch (err) {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,5 +1,6 @@
 import http from 'http';
 
+import {ApiClientType} from '../clients/types';
 import {Session} from '../auth/session';
 import {GraphqlClient} from '../clients/graphql';
 import {RestClient} from '../clients/rest';
@@ -10,6 +11,7 @@ export interface WithSessionParams {
   req?: http.IncomingMessage;
   res?: http.ServerResponse;
   shop?: string;
+  apiType?: ApiClientType;
 }
 
 interface WithSessionBaseResponse {

--- a/src/utils/with-session.ts
+++ b/src/utils/with-session.ts
@@ -3,6 +3,7 @@ import {Session} from '../auth/session';
 import {GraphqlClient} from '../clients/graphql';
 import {RestClient} from '../clients/rest';
 import {Context} from '../context';
+import {ApiClientType} from '../clients/types';
 
 import {WithSessionParams, WithSessionResponse} from './types';
 import loadOfflineSession from './load-offline-session';
@@ -14,6 +15,7 @@ export default async function withSession({
   req,
   res,
   shop,
+  apiType = ApiClientType.Admin,
 }: WithSessionParams): Promise<WithSessionResponse> {
   Context.throwIfUninitialized();
 
@@ -41,13 +43,21 @@ export default async function withSession({
   let client: RestClient | GraphqlClient;
   switch (clientType) {
     case 'rest':
-      client = new RestClient(session.shop, session.accessToken);
+      client = new RestClient({
+        apiType,
+        domain: session.shop,
+        accessToken: session.accessToken,
+      });
       return {
         client,
         session,
       };
     case 'graphql':
-      client = new GraphqlClient(session.shop, session.accessToken);
+      client = new GraphqlClient({
+        apiType,
+        domain: session.shop,
+        accessToken: session.accessToken,
+      });
       return {
         client,
         session,

--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -3,6 +3,7 @@ import http from 'http';
 
 import {StatusCode} from '@shopify/network';
 
+import {ApiClientType} from '../clients/types';
 import {GraphqlClient} from '../clients/graphql/graphql_client';
 import {ShopifyHeader} from '../base_types';
 import ShopifyUtilities from '../utils';
@@ -143,7 +144,11 @@ const WebhooksRegistry: RegistryInterface = {
     deliveryMethod = DeliveryMethod.Http,
     webhookHandler,
   }: RegisterOptions): Promise<RegisterReturn> {
-    const client = new GraphqlClient(shop, accessToken);
+    const client = new GraphqlClient({
+      apiType: ApiClientType.Admin,
+      domain: shop,
+      accessToken,
+    });
     const address = `https://${Context.HOST_NAME}${path}`;
 
     const checkResult = await client.query({


### PR DESCRIPTION
### WHY are these changes introduced?

We're considering adding support for the Storefront API to the GraphQL client. This is a prototype of what that might look like.

### WHAT is this pull request doing?

Rearranging the constructor params for the GraphQL client so that it allows an optional `apiType` setting (which defaults to `Admin`), and changing the client to change the request endpoint accordingly. For consistency, the REST client was also updated so its constructor params work in the same way, even though there is no REST Storefront API.

The constructors were updated in a way that doesn't break existing apps, and we can easily change them when we release a major version (or when we need to add a mandatory param to the client).

An app's code might look like this to make Storefront requests:

```ts
        const client = new Shopify.Clients.Rest({
          domain: myShop,
          accessToken: myToken,
        });
        const sfTokenResponse = await client.post({
          path: 'storefront_access_tokens',
          type: DataType.JSON,
          data: {
            "storefront_access_token": {
              "title": "Test"
            }
          },
        });

        const sfClient = new Shopify.Clients.Graphql({
          apiType: ApiClientType.Storefront,
          domain: myShop,
          accessToken: sfTokenResponse.body['storefront_access_token']['access_token'],
        });
        const sfGqlResponse = await sfClient.query({
          data: `{
            shop {
              name
              primaryDomain {
                url
                host
              }
            }
          }`,
        });
```

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
