### PR TITLE
Throw specific error for missing cookies on OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Allow plain objects to be returned from the `loadCallback` on `CustomSessionStorage` [#126](https://github.com/shopify/shopify-node-api/pull/126)
 
 ### Fixed
-
-
+- Throw a different error for a missing cookie upon OAuth return [#131](https://github.com/shopify/shopify-node-api/pull/131)
 - Improved documentation for GraphQL and Rest Clients. [#123](https://github.com/Shopify/shopify-node-api/pull/123)
 
 ### Fixed

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -106,13 +106,14 @@ const ShopifyOAuth = {
       secure: true,
     });
 
-    let currentSession: Session | undefined;
-
     const sessionCookie = this.getCookieSessionId(request, response);
-    if (sessionCookie) {
-      currentSession = await Context.SESSION_STORAGE.loadSession(sessionCookie);
+    if (!sessionCookie) {
+      throw new ShopifyErrors.CookieNotFound(
+        `Cannot complete OAuth process. Could not find an OAuth cookie for shop url: ${query.shop}`,
+      );
     }
 
+    const currentSession = await Context.SESSION_STORAGE.loadSession(sessionCookie);
     if (!currentSession) {
       throw new ShopifyErrors.SessionNotFound(
         `Cannot complete OAuth process. No session found for the specified shop url: ${query.shop}`,

--- a/src/auth/oauth/test/oauth.test.ts
+++ b/src/auth/oauth/test/oauth.test.ts
@@ -175,7 +175,7 @@ describe('validateAuthCallback', () => {
       ShopifyOAuth.validateAuthCallback(req, res, {
         shop: 'I do not exist',
       } as AuthQuery),
-    ).rejects.toThrow(ShopifyErrors.SessionNotFound);
+    ).rejects.toThrow(ShopifyErrors.CookieNotFound);
   });
 
   test('throws an error when receiving a callback for a shop with no saved session', async () => {

--- a/src/error.ts
+++ b/src/error.ts
@@ -31,6 +31,7 @@ class HttpThrottlingError extends HttpRetriableError {
 
 class InvalidOAuthError extends ShopifyError {}
 class SessionNotFound extends ShopifyError {}
+class CookieNotFound extends ShopifyError {}
 class InvalidSession extends ShopifyError {}
 
 class InvalidWebhookError extends ShopifyError {}
@@ -55,6 +56,7 @@ export {
   UninitializedContextError,
   InvalidOAuthError,
   SessionNotFound,
+  CookieNotFound,
   InvalidSession,
   InvalidWebhookError,
   MissingRequiredArgument,


### PR DESCRIPTION
### WHY are these changes introduced?

As mentioned on https://github.com/Shopify/koa-shopify-auth/issues/61#issuecomment-794850778, we were throwing the same error (`SessionNotFound`) if the session itself was missing, or if the cookie the holds its id was missing, which can be confusing when errors happen.

### WHAT is this pull request doing?

Throwing a specific `CookieNotFound` error if we can't load the session id from the cookie to make it easier to surface issues to apps.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
- [ ] ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~
