### PR TITLE
Adding April21 version

### DIFF
--- a/src/base_types.ts
+++ b/src/base_types.ts
@@ -23,6 +23,7 @@ export enum ApiVersion {
   July20 = '2020-07',
   October20 = '2020-10',
   January21 = '2021-01',
+  April21 = '2021-04',
   Unstable = 'unstable',
   Unversioned = 'unversioned',
 }


### PR DESCRIPTION
Fixes #148 

This PR just adds `April21` as an option for `ApiVersion`, since that RC version is already available.