### PR TITLE
[WIP] Ensure scopes defined in `scopes.equals()`

### DIFF
--- a/src/auth/scopes/index.ts
+++ b/src/auth/scopes/index.ts
@@ -1,3 +1,5 @@
+//import {MissingRequiredArgument} from '../../error';
+
 class AuthScopes {
   public static SCOPE_DELIMITER = ',';
 
@@ -37,6 +39,10 @@ class AuthScopes {
 
   public equals(otherScopes: string | string[] | AuthScopes) {
     let other: AuthScopes;
+
+    // if (!otherScopes) {
+    //   throw new MissingRequiredArgument('Missing scopes');
+    // }
 
     if (otherScopes instanceof AuthScopes) {
       other = otherScopes;

--- a/src/auth/scopes/test/scopes.test.ts
+++ b/src/auth/scopes/test/scopes.test.ts
@@ -1,4 +1,5 @@
 import '../../../test/test_helper';
+import * as ShopifyErrors from '../../../error';
 
 import {AuthScopes} from '../index';
 
@@ -64,6 +65,13 @@ describe('AuthScopes.equals', () => {
     expect(scopes1.equals(scopes2)).toBeFalsy();
     expect(scopes2.equals(scopes1)).toBeFalsy();
   });
+
+  it('throws an error if no scopes', () => {
+    const scopes1 = new AuthScopes('write_customers,read_products');
+    const scopes2: string = '';
+    
+    expect(scopes1.equals(scopes2)).toThrow(ShopifyErrors.MissingRequiredArgument);
+  })
 
   it('allows comparing against strings', () => {
     const scopes1 = new AuthScopes('write_customers,read_products,write_products');


### PR DESCRIPTION
### Why are these changes introduced? 🤔 
* Fixes #159

### What is this pull request doing? 📋 
* Checks scopes exist before doing the rest of `equals()`

## Type of change
- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist
- [ ] ~I have added a changelog entry, prefixed by the type of change noted above~
- [ ] I have added/updated tests for this change
- [ ] ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~
