### PR TITLE
Add support for PubSub webhook registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add support for registering Google Pub/Sub webhooks [#181](https://github.com/Shopify/shopify-node-api/pull/181)
+- Added `July21` to `ApiVersion` [#181](https://github.com/Shopify/shopify-node-api/pull/181)
 
 ## [1.3.0] - 2021-05-12
 ### Added

--- a/docs/usage/webhooks.md
+++ b/docs/usage/webhooks.md
@@ -74,6 +74,20 @@ app.get('/auth/callback', async (req, res) => {
 ```
 </details>
 
+### EventBridge and PubSub Webhooks
+
+You can also register webhooks for delivery to Amazon EventBridge or Google Cloud
+Pub/Sub. In this case the `path` argument to
+`Shopify.Webhooks.Registry.register` needs to be of a specific form.
+
+For EventBridge, the `path` must be the [ARN of the partner event
+source](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_EventSource.html).
+
+For Pub/Sub, the `path` must be of the form
+`pubsub://[PROJECT-ID]:[PUB-SUB-TOPIC-ID]`.  For example, if you created a topic
+with id `red` in the project `blue`, then the value of `path` would be
+`pubsub://red:blue`.
+
 ## Process a Webhook
 
 To process a webhook, you need to listen on the route(s) you provided during the Webhook registration process, then call the appropriate handler.  The library provides a convenient `process` method that acts as a middleware to handle webhooks. It takes care of calling the correct handler for the registered Webhook topics.

--- a/src/base_types.ts
+++ b/src/base_types.ts
@@ -25,6 +25,7 @@ export enum ApiVersion {
   October20 = '2020-10',
   January21 = '2021-01',
   April21 = '2021-04',
+  July21 = '2021-07',
   Unstable = 'unstable',
   Unversioned = 'unversioned',
 }

--- a/src/webhooks/types.ts
+++ b/src/webhooks/types.ts
@@ -1,6 +1,7 @@
 export enum DeliveryMethod {
   Http = 'http',
   EventBridge = 'eventbridge',
+  PubSub = 'pubsub',
 }
 
 type WebhookHandlerFunction = (
@@ -37,6 +38,10 @@ interface WebhookCheckResponseNode<T = {
   } | {
     __typename: 'WebhookEventBridgeEndpoint';
     arn: string;
+  } | {
+    __typename: 'WebhookPubSubEndpoint';
+    pubSubProject: string;
+    pubSubTopic: string;
   };
 }> {
   node: {


### PR DESCRIPTION
### WHY are these changes introduced?

We will soon have support for webhook delivery via Google Cloud PubSub.
We need to update the webhook registration function in this library to support this new delivery method.

### WHAT is this pull request doing?

The `register` function already takes in a `DeliveryMethod`. This PR adds a new `DeliveryMethod.PubSub`,
and implements the appropriate behaviour for it. In particular, `register` hits the new `pubSubWebhookSubscriptionCreate`
and `pubSubWebhookSubscriptionUpdate` endpoints in the GraphQL API.

This PR also adds some documentation about registering non-HTTP-delivery webhooks (the docs for
EventBridge webhooks were missing as well).

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
