### PR TITLE
Add addHandler and getHandler functions

### DIFF
--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -22,6 +22,20 @@ interface RegistryInterface {
   webhookRegistry: WebhookRegistryEntry[];
 
   /**
+   * Sets the handler for the given topic. If a handler was previously set for the same topic, it will be overridden.
+   *
+   * @param options Paramters to add a handler which are topic and webHookHandler
+   */
+  addHandler(options: WebhookRegistryEntry): Promise<void>;
+
+  /**
+   * Fetches the handler for the given topic. Returns null if no handler was registered.
+   *
+   * @param topic The topic to check
+   */
+  getHandler(topic: string): Promise<WebhookRegistryEntry | null>;
+
+  /**
    * Registers a Webhook Handler function for a given topic.
    *
    * @param options Parameters to register a handler, including topic, listening address, handler function
@@ -177,6 +191,16 @@ function buildQuery(
 const WebhooksRegistry: RegistryInterface = {
   webhookRegistry: [],
 
+  async addHandler({path, topic, webhookHandler}): Promise<void> {
+    WebhooksRegistry.webhookRegistry = WebhooksRegistry.webhookRegistry.filter((item) => item.topic !== topic);
+    WebhooksRegistry.webhookRegistry.push({path, topic, webhookHandler});
+  },
+
+  async getHandler(topic) {
+    const webhookEntry = WebhooksRegistry.webhookRegistry.find((entry) => entry.topic === topic);
+    return (webhookEntry) ? webhookEntry : null;
+  },
+
   async register({
     path,
     topic,
@@ -185,6 +209,9 @@ const WebhooksRegistry: RegistryInterface = {
     deliveryMethod = DeliveryMethod.Http,
     webhookHandler,
   }: RegisterOptions): Promise<RegisterReturn> {
+    if (webhookHandler) console.log(
+      'This method of passing in the webhook is now deprecated. Please use the addHandler function.'
+    );
     validateDeliveryMethod(deliveryMethod);
     const client = new GraphqlClient(shop, accessToken);
     const address = deliveryMethod === DeliveryMethod.Http
@@ -225,12 +252,6 @@ const WebhooksRegistry: RegistryInterface = {
     } else {
       success = true;
       body = {};
-    }
-
-    if (success) {
-      // Remove this topic from the registry if it is already there
-      WebhooksRegistry.webhookRegistry = WebhooksRegistry.webhookRegistry.filter((item) => item.topic !== topic);
-      WebhooksRegistry.webhookRegistry.push({path, topic, webhookHandler});
     }
 
     return {success, result: body};

--- a/src/webhooks/types.ts
+++ b/src/webhooks/types.ts
@@ -16,7 +16,7 @@ export interface RegisterOptions {
   path: string;
   shop: string;
   accessToken: string;
-  webhookHandler: WebhookHandlerFunction;
+  webhookHandler?: WebhookHandlerFunction;
   deliveryMethod?: DeliveryMethod;
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

- Refactored the `register` function


### WHAT is this pull request doing?

- added a console.log that lets the 3p developer know that the method is deprecated for `loadHandler` with handler
- extract a `loadHandler` method out of `register` that just adds the handler to the registry, and make the handler parameter optional in `register` to not break things

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
