### PR TITLE
Add support for custom location protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ coverage/
 yarn-error.log
 tsdocs/
 tsconfig.tsbuildinfo
+/.idea/inspectionProfiles/Project_Default.xml
+/.idea/.gitignore
+/.idea/modules.xml
+/.idea/shopify-node-api.iml
+/.idea/vcs.xml

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -72,7 +72,7 @@ const ShopifyOAuth = {
     const query = {
       client_id: Context.API_KEY,
       scope: Context.SCOPES.toString(),
-      redirect_uri: `https://${Context.HOST_NAME}${redirectPath}`,
+      redirect_uri: `${Context.PROTOCOL}//${Context.HOST_NAME}${redirectPath}`,
       state,
       'grant_options[]': isOnline ? 'per-user' : '',
     };

--- a/src/auth/oauth/test/oauth.test.ts
+++ b/src/auth/oauth/test/oauth.test.ts
@@ -93,7 +93,7 @@ describe('beginAuth', () => {
     const query = {
       client_id: Context.API_KEY,
       scope: Context.SCOPES.toString(),
-      redirect_uri: `https://${Context.HOST_NAME}/some-callback`,
+      redirect_uri: `${Context.PROTOCOL}//${Context.HOST_NAME}/some-callback`,
       state: session ? session.state : '',
       'grant_options[]': '',
     };
@@ -112,7 +112,7 @@ describe('beginAuth', () => {
     const query = {
       client_id: Context.API_KEY,
       scope: Context.SCOPES.toString(),
-      redirect_uri: `https://${Context.HOST_NAME}/some-callback`,
+      redirect_uri: `${Context.PROTOCOL}//${Context.HOST_NAME}/some-callback`,
       state: session ? session.state : '',
       'grant_options[]': 'per-user',
     };

--- a/src/base_types.ts
+++ b/src/base_types.ts
@@ -6,6 +6,7 @@ export interface ContextParams {
   API_SECRET_KEY: string;
   SCOPES: string[] | AuthScopes;
   HOST_NAME: string;
+  PROTOCOL?: 'http:' | 'https:';
   API_VERSION: ApiVersion;
   IS_EMBEDDED_APP: boolean;
   IS_PRIVATE_APP?: boolean;

--- a/src/context.ts
+++ b/src/context.ts
@@ -31,6 +31,7 @@ const Context: ContextInterface = {
   API_SECRET_KEY: '',
   SCOPES: new AuthScopes([]),
   HOST_NAME: '',
+  PROTOCOL: 'https:',
   API_VERSION: ApiVersion.Unstable,
   IS_EMBEDDED_APP: true,
   IS_PRIVATE_APP: false,

--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -188,7 +188,7 @@ const WebhooksRegistry: RegistryInterface = {
     validateDeliveryMethod(deliveryMethod);
     const client = new GraphqlClient(shop, accessToken);
     const address = deliveryMethod === DeliveryMethod.Http
-      ? `https://${Context.HOST_NAME}${path}`
+      ? `${Context.PROTOCOL}//${Context.HOST_NAME}${path}`
       : path;
     const checkResult = await client.query({
       data: buildCheckQuery(topic),

--- a/src/webhooks/test/registry.test.ts
+++ b/src/webhooks/test/registry.test.ts
@@ -689,7 +689,7 @@ function assertWebhookCheckRequest(webhook: RegisterOptions) {
 function assertWebhookRegistrationRequest(webhook: RegisterOptions, webhookId?: string) {
   const address =
     !webhook.deliveryMethod || webhook.deliveryMethod === DeliveryMethod.Http
-      ? `https://${Context.HOST_NAME}${webhook.path}`
+      ? `${Context.PROTOCOL}//${Context.HOST_NAME}${webhook.path}`
       : webhook.path;
   assertHttpRequest({
     method: Method.Post.toString(),


### PR DESCRIPTION
### WHY are these changes introduced?

I'm on local development and don't want to use `ngrok` to publish my NodeJS server because it might slow sometimes.
Add this protocol support to allow us to use `localhost:3000` without the need of faking an SSL certificate.


### WHAT is this pull request doing?

Added `PROTOCOL` to the `Shopify.Context`, by default it always is `https:`

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
