### PR TITLE
Update webhooks.md - method uses incorrect prop variables

### DIFF
--- a/docs/usage/webhooks.md
+++ b/docs/usage/webhooks.md
@@ -66,8 +66,8 @@ app.get('/auth/callback', async (req, res) => {
     };
 
     const currentSession = await Shopify.Utils.loadCurrentSession(
-      request,
-      response,
+      req,
+      res,
     );
 
     // See https://shopify.dev/docs/admin-api/graphql/reference/events/webhooksubscriptiontopic for a list of available topics


### PR DESCRIPTION
Register webhooks section (Express) loadCurrentSession method uses `request` and `response` props instead of `req` and `res` as returned in the callback

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes a typo in the docs

<!--
  Context about the problem that’s being addressed.
-->


## Type of change

- [x] Doc Update


