### PR TITLE
[Feature] Add support for http2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/node-fetch": "^2.5.7",
     "@types/supertest": "^2.0.10",
-    "cookies": "^0.8.0",
+    "cookie": "0.4.1",
     "jsonwebtoken": "^8.5.1",
     "node-fetch": "^2.6.1",
     "tslib": "^2.0.3",
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@shopify/eslint-plugin": "^39.0.3",
     "@shopify/prettier-config": "^1.1.2",
-    "@types/cookies": "^0.7.5",
+    "@types/cookie": "0.4.1",
     "@types/jest": "^26.0.15",
     "@types/node": "^14.14.1",
     "@types/uuid": "^8.3.0",

--- a/src/test/context.test.ts
+++ b/src/test/context.test.ts
@@ -1,12 +1,8 @@
 import './test_helper';
 
-import Cookies from 'cookies';
-
 import * as ShopifyErrors from '../error';
 import {Context} from '../context';
 import {ApiVersion, ContextParams} from '../base_types';
-
-jest.mock('cookies');
 
 const validParams: ContextParams = {
   API_KEY: 'api_key',
@@ -24,7 +20,6 @@ const originalWarn = console.warn;
 describe('Context object', () => {
   afterEach(() => {
     console.warn = originalWarn;
-    (Cookies as any).mockClear();
   });
 
   it('can initialize and update context', () => {

--- a/src/utils/delete-current-session.ts
+++ b/src/utils/delete-current-session.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import http2 from 'http2';
 
 import {Context} from '../context';
 import {ShopifyOAuth} from '../auth/oauth/oauth';
@@ -12,8 +13,8 @@ import * as ShopifyErrors from '../error';
  * @param isOnline Whether to load online (default) or offline sessions (optional)
  */
 export default async function deleteCurrentSession(
-  request: http.IncomingMessage,
-  response: http.ServerResponse,
+  request: http.IncomingMessage | http2.Http2ServerRequest,
+  response: http.ServerResponse | http2.Http2ServerResponse,
   isOnline = true,
 ): Promise<boolean | never> {
   Context.throwIfUninitialized();

--- a/src/utils/load-current-session.ts
+++ b/src/utils/load-current-session.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import http2 from 'http2';
 
 import {Context} from '../context';
 import {ShopifyOAuth} from '../auth/oauth/oauth';
@@ -12,8 +13,8 @@ import {Session} from '../auth/session';
  * @param isOnline Whether to load online (default) or offline sessions (optional)
  */
 export default async function loadCurrentSession(
-  request: http.IncomingMessage,
-  response: http.ServerResponse,
+  request: http.IncomingMessage | http2.Http2ServerRequest,
+  response: http.ServerResponse | http2.Http2ServerResponse,
   isOnline = true,
 ): Promise<Session | undefined> {
   Context.throwIfUninitialized();

--- a/src/utils/safe-compare.ts
+++ b/src/utils/safe-compare.ts
@@ -9,8 +9,8 @@ import * as ShopifyErrors from '../error';
  * @param strB any string, array of strings, or object with string values
  */
 export default function safeCompare(
-  strA: string | Record<string, string> | string[] | number[],
-  strB: string | Record<string, string> | string[] | number[],
+  strA: Parameters<typeof Buffer.from>[0],
+  strB: Parameters<typeof Buffer.from>[0],
 ): boolean {
   if (typeof strA === typeof strB) {
     let buffA: Buffer;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import http2 from 'http2';
 
 import {Session} from '../auth/session';
 import {GraphqlClient} from '../clients/graphql';
@@ -7,8 +8,8 @@ import {RestClient} from '../clients/rest';
 export interface WithSessionParams {
   clientType: 'rest' | 'graphql';
   isOnline: boolean;
-  req?: http.IncomingMessage;
-  res?: http.ServerResponse;
+  req?: http.IncomingMessage | http2.Http2ServerRequest;
+  res?: http.ServerResponse | http2.Http2ServerResponse;
   shop?: string;
 }
 

--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -1,5 +1,6 @@
 import {createHmac} from 'crypto';
 import http from 'http';
+import http2 from 'http2';
 
 import {StatusCode} from '@shopify/network';
 
@@ -35,8 +36,8 @@ interface RegistryInterface {
    * @param response HTTP response to the request
    */
   process(
-    request: http.IncomingMessage,
-    response: http.ServerResponse,
+    request: http.IncomingMessage | http2.Http2ServerRequest,
+    response: http.ServerResponse | http2.Http2ServerResponse,
   ): Promise<void>;
 
   /**
@@ -266,8 +267,8 @@ const WebhooksRegistry: RegistryInterface = {
   },
 
   async process(
-    request: http.IncomingMessage,
-    response: http.ServerResponse,
+    request: http.IncomingMessage | http2.Http2ServerRequest,
+    response: http.ServerResponse | http2.Http2ServerResponse,
   ): Promise<void> {
     let reqBody = '';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -884,59 +884,20 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/body-parser@*":
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz"
-  integrity sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==
-  dependencies:
-    "@types/connect" "*"
-    "@types/node" "*"
-
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/connect@*":
-  version "3.4.33"
-  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz"
-  integrity sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
-  dependencies:
-    "@types/node" "*"
+"@types/cookie@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
 
 "@types/cookiejar@*":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
   integrity sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==
-
-"@types/cookies@^0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@types/cookies/-/cookies-0.7.5.tgz"
-  integrity sha512-3+TAFSm78O7/bAeYdB8FoYGntuT87vVP9JKuQRL8sRhv9313LP2SpHHL50VeFtnyjIcb3UELddMk5Yt0eOSOkg==
-  dependencies:
-    "@types/connect" "*"
-    "@types/express" "*"
-    "@types/keygrip" "*"
-    "@types/node" "*"
-
-"@types/express-serve-static-core@*":
-  version "4.17.13"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz"
-  integrity sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==
-  dependencies:
-    "@types/node" "*"
-    "@types/qs" "*"
-    "@types/range-parser" "*"
-
-"@types/express@*":
-  version "4.17.9"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.9.tgz"
-  integrity sha512-SDzEIZInC4sivGIFY4Sz1GG6J9UObPwCInYJjko2jzOf/Imx/dlpume6Xxwj1ORL82tBbmN4cPDIDkLbWHk9hw==
-  dependencies:
-    "@types/body-parser" "*"
-    "@types/express-serve-static-core" "*"
-    "@types/qs" "*"
-    "@types/serve-static" "*"
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.3"
@@ -984,16 +945,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/keygrip@*":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@types/keygrip/-/keygrip-1.0.2.tgz"
-  integrity sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==
-
-"@types/mime@*":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz"
-  integrity sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==
-
 "@types/node-fetch@^2.5.7":
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz"
@@ -1026,24 +977,6 @@
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.0.tgz"
   integrity sha512-hiYA88aHiEIgDmeKlsyVsuQdcFn3Z2VuFd/Xm/HCnGnPD8UFU5BM128uzzRVVGEzKDKYUrRsRH9S2o+NUy/3IA==
-
-"@types/qs@*":
-  version "6.9.5"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.5.tgz"
-  integrity sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==
-
-"@types/range-parser@*":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz"
-  integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
-
-"@types/serve-static@*":
-  version "1.13.8"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.8.tgz"
-  integrity sha512-MoJhSQreaVoL+/hurAZzIm8wafFR6ajiTM1m4A0kv6AGeVBl4r4pOV8bGFrjjq1sGxDTnCoF8i22o0/aE5XCyA==
-  dependencies:
-    "@types/mime" "*"
-    "@types/node" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -1855,18 +1788,15 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
+cookie@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
 cookiejar@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz"
   integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
-
-cookies@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.8.0.tgz"
-  integrity sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==
-  dependencies:
-    depd "~2.0.0"
-    keygrip "~1.1.0"
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -2074,11 +2004,6 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
-
-depd@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz"
-  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 destroy@~1.0.4:
   version "1.0.4"
@@ -4193,13 +4118,6 @@ jws@^3.2.2:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
-keygrip@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.1.0.tgz"
-  integrity sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==
-  dependencies:
-    tsscmp "1.0.6"
-
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz"
@@ -6102,11 +6020,6 @@ tslib@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
-
-tsscmp@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz"
-  integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
The cookie related methods were not compatible with http2.

### WHY are these changes introduced?

The current version does not support the http2 types of the request/response Node objects. This makes it impossible to use the package in a http2 server written in Typescript, unless you are OK with ignoring the type errors.

### WHAT is this pull request doing?

Replace the [cookies package](https://www.npmjs.com/package/cookies) (which also writes the response header) with the [cookie package](https://www.npmjs.com/package/cookie) (which just parses cookie strings). This requires to manually set and read the cookie header, but gives greater control and allows to also work with the http2 request/response interfaces.

One thing to note is that the new cookie package won't sign cookies. My understanding is that this is not necessary when using `secure` and `httponly` cookies, but **should be confirmed be a security expert**.  This change could potentially break existing cookies, but should "just" cause a new login flow, which then updates to an unsigned cookie. 

I have added `@ts-ignore` comments to ignore unused variable errors for the arguments of `getCookieSessionId` and `setCookieSessionId` in order to not introduce a breaking change in the api surface.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
