### PR TITLE
Added regex for spin in the shop URL validator

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -26,7 +26,7 @@ Tip: include an error message (in a `<details></details>` tag) if your issue is 
 
 ## Reduced test case
 
-The best way to get your bug fixed is to provide a [reduced test case](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Reducing_testcases).
+The best way to get your bug fixed is to provide a [reduced test case](https://webkit.org/test-case-reduction/).
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -26,7 +26,7 @@ Tip: include an error message (in a `<details></details>` tag) if your issue is 
 
 ## Reduced test case
 
-The best way to get your bug fixed is to provide a [reduced test case](https://webkit.org/test-case-reduction/).
+The best way to get your bug fixed is to provide a [reduced test case](https://web.archive.org/web/20210306034028/https://developer.mozilla.org/en-US/docs/Mozilla/QA/Reducing_testcases).
 
 ---
 

--- a/src/utils/shop-validator.ts
+++ b/src/utils/shop-validator.ts
@@ -4,6 +4,6 @@
  * @param shop Shop url: {shop}.myshopify.com
  */
 export default function validateShop(shop: string): boolean {
-  const shopUrlRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.(com|io)[/]*$/;
+  const shopUrlRegex = /(^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.(com|io)[/]*$|^[a-zA-Z0-9][a-zA-Z0-9-]*\.shopify\.[a-zA-Z0-9][a-zA-Z0-9-]*\.[a-zA-Z0-9][a-zA-Z0-9-]*\.(us|asia|eu)\.spin.dev[/]*$)/;
   return shopUrlRegex.test(shop);
 }

--- a/src/utils/test/shop-validator.test.ts
+++ b/src/utils/test/shop-validator.test.ts
@@ -23,3 +23,27 @@ test("returns false for invalid shop urls, even if they contain the string 'mysh
   const shopUrl = 'notshopify.myshopify.io.org/potato';
   expect(validateShop(shopUrl)).toBe(false);
 });
+
+test('returns true for spin shop urls', () => {
+  const shopUrlUS = 'shop1.shopify.workspace.namespace.us.spin.dev';
+  const shopUrlAsia = 'shop1.shopify.workspace.namespace.asia.spin.dev';
+  const shopUrlEU = 'shop1.shopify.workspace.namespace.eu.spin.dev';
+  expect(validateShop(shopUrlUS)).toBe(true);
+  expect(validateShop(shopUrlAsia)).toBe(true);
+  expect(validateShop(shopUrlEU)).toBe(true);
+});
+
+test('returns false for missing workspace', () => {
+  const shopUrl = 'shop1.shopify.namespace.us.spin.dev';
+  expect(validateShop(shopUrl)).toBe(false);
+});
+
+test('returns false for missing workspace', () => {
+  const shopUrl = 'shop1.shopify.workspace.us.spin.dev';
+  expect(validateShop(shopUrl)).toBe(false);
+});
+
+test('returns false for wrong region', () => {
+  const shopUrl = 'shop1.shopify.workspace.namespace.ca.spin.dev';
+  expect(validateShop(shopUrl)).toBe(false);
+});


### PR DESCRIPTION
### WHY are these changes introduced?

With the introduction of spin, when installing an app on a shop you receive an oauth redirection error.

### WHAT is this pull request doing?

Added to the regex to support spin and it's various URL contexts.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
  - I didn't feel the change was notable so I didn't update the change
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
