### PR TITLE
Update reduced test case link

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -26,7 +26,7 @@ Tip: include an error message (in a `<details></details>` tag) if your issue is 
 
 ## Reduced test case
 
-The best way to get your bug fixed is to provide a [reduced test case](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Reducing_testcases).
+The best way to get your bug fixed is to provide a [reduced test case](https://webkit.org/test-case-reduction/).
 
 ---
 


### PR DESCRIPTION
Our CI is catching a broken link in the bug report

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

developer.mozilla.org removed their test case page, but webkit has one.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
