### PR TITLE
Expand objects in HTTP request error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed the HTTP client error messages to expand objects [#252](https://github.com/Shopify/shopify-node-api/pull/252)
+
 ## [1.4.2] - 2021-10-20
 
 - Added `October21` to `ApiVersion` [#247](https://github.com/Shopify/shopify-node-api/pull/247)

--- a/src/clients/http_client/http_client.ts
+++ b/src/clients/http_client/http_client.ts
@@ -223,7 +223,7 @@ class HttpClient {
         } else {
           const errorMessages: string[] = [];
           if (body.errors) {
-            errorMessages.push(body.errors);
+            errorMessages.push(JSON.stringify(body.errors, null, 2));
           }
           if (response.headers && response.headers.get('x-request-id')) {
             errorMessages.push(
@@ -234,7 +234,7 @@ class HttpClient {
           }
 
           const errorMessage = errorMessages.length
-            ? `: ${errorMessages.join('. ')}`
+            ? `:\n${errorMessages.join('\n')}`
             : '';
           switch (true) {
             case response.status === StatusCode.TooManyRequests: {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #220
Fixes #237 
Fixes #250 

We can sometimes receive error messages that are not strings, and we were not printing them properly before.

### WHAT is this pull request doing?

Printing the error messages as JSON so that we can handle any type of error.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
- [X] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
