### PR TITLE
There is a typo as it should be res.send()

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -207,7 +207,7 @@ app.get("/", async (req, res) => {
   } else {
     res.send("Hello world!");
     // Load your app skeleton page with App Bridge, and do something amazing!
-    response.end();
+    res.end();
   }
 });
 


### PR DESCRIPTION
There is a type Inside `app.get()`, we are using `response.end()` when it should be `res.end()` based on the parameters we are using.