### PR TITLE
Allow full paths in REST requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 ### Added
+
+- Allow full paths in REST requests [#301](https://github.com/Shopify/shopify-node-api/pull/301)
+
 ### Fixed
 
 ## [2.1.0] - 2022-02-03

--- a/docs/usage/rest.md
+++ b/docs/usage/rest.md
@@ -14,7 +14,7 @@ The `RestClient` offers the 4 core request methods: `get`, `delete`, `post`, and
 **`GetRequestParams` / `DeleteRequestParams`:**
 | Parameter | Type | Required? | Default Value | Notes |
 | -------------- | ----------------------------------- | :-------: | :-----------: | ---------------------------------------------------------------------------------------- |
-| `path` | `string` | True | none | The requested API endpoint path |
+| `path` | `string` | True | none | The requested API endpoint path. This can be one of two formats:<ul><li>The path starting after the `/admin/api/{version}/` prefix, such as `'products'`, which executes `/admin/api/{version}/products.json`</li><li>The full path, such as `/admin/oauth/access_scopes.json`</li></ul> |
 | `data` | `Record<string, unknown> \| string` | False | none | The body of the request |
 | `type` | `DataType` | False | none | The type of data being sent in the body of the request (`JSON`, `GraphQL`, `URLEncoded`) |
 | `query` | `Record<string, string \| number>` | False | none | An optional query object to be appended to the request |
@@ -29,7 +29,7 @@ The `RestClient` offers the 4 core request methods: `get`, `delete`, `post`, and
 **`PostRequestParams` / `PutRequestParams`:**
 | Parameter | Type | Required? | Default Value | Notes |
 | -------------- | ----------------------------------- | :-------: | :-----------: | ---------------------------------------------------------------------------------------- |
-| `path` | `string` | True | none | The requested API endpoint path |
+| `path` | `string` | True | none | The requested API endpoint path. This can be one of two formats:<ul><li>The path starting after the `/admin/api/{version}/` prefix, such as `'products'`, which executes `/admin/api/{version}/products.json`</li><li>The full path, such as `/admin/oauth/access_scopes.json`</li></ul> |
 | `data` | `Record<string, unknown> \| string` | True | none | The body of the request |
 | `type` | `DataType` | True | none | The type of data being sent in the body of the request (`JSON`, `GraphQL`, `URLEncoded`) |
 | `query` | `Record<string, string \| number>` | False | none | An optional query object to be appended to the request |

--- a/src/clients/http_client/http_client.ts
+++ b/src/clients/http_client/http_client.ts
@@ -120,7 +120,7 @@ class HttpClient {
       ? `?${querystring.stringify(params.query as ParsedUrlQueryInput)}`
       : '';
 
-    const url = `https://${this.domain}${params.path}${queryString}`;
+    const url = `https://${this.domain}${this.getRequestPath(params.path)}${queryString}`;
     const options: RequestInit = {
       method: params.method.toString(),
       headers,
@@ -169,6 +169,10 @@ class HttpClient {
     throw new ShopifyErrors.ShopifyError(
       `Unexpected flow, reached maximum HTTP tries but did not throw an error`,
     );
+  }
+
+  protected getRequestPath(path: string): string {
+    return `/${path.replace(/^\//, '')}`;
   }
 
   private async doRequest(

--- a/src/clients/http_client/test/http_client.test.ts
+++ b/src/clients/http_client/test/http_client.test.ts
@@ -715,6 +715,17 @@ describe('HTTP client', () => {
     expect(caught).toEqual(true);
     assertHttpRequest({method: 'GET', domain, path: '/url/path'});
   });
+
+  it('adds missing slashes to paths', async () => {
+    const client = new HttpClient(domain);
+
+    fetchMock.mockResponseOnce(buildMockResponse(successResponse));
+
+    await expect(client.get({path: 'url/path'})).resolves.toEqual(
+      buildExpectedResponse(successResponse),
+    );
+    assertHttpRequest({method: 'GET', domain, path: '/url/path'});
+  });
 });
 
 function setRestClientRetryTime(time: number) {

--- a/src/clients/rest/rest_client.ts
+++ b/src/clients/rest/rest_client.ts
@@ -30,8 +30,6 @@ class RestClient extends HttpClient {
       ...params.extraHeaders,
     };
 
-    params.path = this.getRestPath(params.path);
-
     const ret = (await super.request(params)) as RestRequestReturn;
 
     const link = ret.headers.get('link');
@@ -81,8 +79,13 @@ class RestClient extends HttpClient {
     return ret;
   }
 
-  private getRestPath(path: string): string {
-    return `/admin/api/${Context.API_VERSION}/${path}.json`;
+  protected getRequestPath(path: string): string {
+    const cleanPath = super.getRequestPath(path);
+    if (cleanPath.startsWith('/admin')) {
+      return `${cleanPath.replace(/\.json$/, '')}.json`;
+    } else {
+      return `/admin/api/${Context.API_VERSION}${cleanPath.replace(/\.json$/, '')}.json`;
+    }
   }
 
   private buildRequestParams(newPageUrl: string): GetRequestParams {

--- a/src/clients/rest/test/rest_client.test.ts
+++ b/src/clients/rest/test/rest_client.test.ts
@@ -342,6 +342,36 @@ describe('REST client', () => {
       ShopifyErrors.MissingRequiredArgument,
     );
   });
+
+  it('allows paths with .json', async () => {
+    const client = new RestClient(domain, 'dummy-token');
+
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+
+    await expect(client.get({path: 'products.json'})).resolves.toEqual(
+      buildExpectedResponse(successResponse),
+    );
+    assertHttpRequest({
+      method: 'GET',
+      domain,
+      path: '/admin/api/unstable/products.json',
+    });
+  });
+
+  it('allows full paths', async () => {
+    const client = new RestClient(domain, 'dummy-token');
+
+    fetchMock.mockResponseOnce(JSON.stringify(successResponse));
+
+    await expect(client.get({path: '/admin/some-path.json'})).resolves.toEqual(
+      buildExpectedResponse(successResponse),
+    );
+    assertHttpRequest({
+      method: 'GET',
+      domain,
+      path: '/admin/some-path.json',
+    });
+  });
 });
 
 function getDefaultPageInfo(): PageInfo {


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, we can't handle requests like access scopes (`/admin/oauth/access_scopes.json`) or token access (`/admin/api_permissions/current.json`), because these resources use custom paths instead of the default `/admin/api/{version}/...`.

This means we can't easily reach those endpoints unless the code uses the base HTTP client that the REST one is built upon, which makes things unnecessarily complicated.

### WHAT is this pull request doing?

This PR solves that problem by allowing REST calls in the Admin API client to be made using a full path. Therefore, requests like

```js
const client = new RestClient(domain, 'token');
const response = await client.get({path: '/admin/some-path.json'});
```

work just like any regular request would.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
- [X] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
