### PR TITLE
Stop sending request response from the GraphQL proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- ⚠️ [Breaking] Stop responding to the request in the GraphQL Proxy function, returning Shopify's response instead [#312](https://github.com/Shopify/shopify-node-api/pull/312)
+
 ## [2.1.0] - 2022-02-03
 
 ### Added

--- a/src/utils/__tests__/graphql_proxy.test.ts
+++ b/src/utils/__tests__/graphql_proxy.test.ts
@@ -1,7 +1,7 @@
 import http from 'http';
 
 import jwt from 'jsonwebtoken';
-import express from 'express';
+import express, {Request, Response} from 'express';
 import request from 'supertest';
 
 import {Session} from '../../auth/session';
@@ -39,6 +39,17 @@ const accessToken = 'dangit';
 let token = '';
 
 describe('GraphQL proxy with session', () => {
+  const app = express();
+  app.post('/proxy', async (req: Request, res: Response) => {
+    try {
+      const response = await graphqlProxy(req, res);
+      res.send(response.body);
+    } catch (err) {
+      res.status(400);
+      res.send(JSON.stringify(err.message));
+    }
+  });
+
   beforeEach(async () => {
     Context.IS_EMBEDDED_APP = true;
     Context.initialize(Context);
@@ -68,9 +79,6 @@ describe('GraphQL proxy with session', () => {
   });
 
   it('can forward query and return response', async () => {
-    const app = express();
-    app.post('/proxy', graphqlProxy);
-
     fetchMock.mockResponses(
       JSON.stringify(successResponse),
       JSON.stringify(successResponse),
@@ -94,9 +102,6 @@ describe('GraphQL proxy with session', () => {
   });
 
   it('rejects if no query', async () => {
-    const app = express();
-    app.post('/proxy', graphqlProxy);
-
     const response = await request(app)
       .post('/proxy')
       .set('authorization', `Bearer ${token}`)

--- a/src/utils/graphql_proxy.ts
+++ b/src/utils/graphql_proxy.ts
@@ -1,6 +1,7 @@
 import http from 'http';
 
 import {GraphqlClient} from '../clients/graphql';
+import {RequestReturn} from '../clients/http_client/types';
 import * as ShopifyErrors from '../error';
 
 import loadCurrentSession from './load-current-session';
@@ -8,7 +9,7 @@ import loadCurrentSession from './load-current-session';
 export default async function graphqlProxy(
   userReq: http.IncomingMessage,
   userRes: http.ServerResponse,
-): Promise<void> {
+): Promise<RequestReturn> {
   const session = await loadCurrentSession(userReq, userRes);
   if (!session) {
     throw new ShopifyErrors.SessionNotFound(
@@ -24,7 +25,7 @@ export default async function graphqlProxy(
   const token: string = session.accessToken;
   let reqBodyString = '';
 
-  const promise: Promise<void> = new Promise((resolve, _reject) => {
+  return new Promise((resolve, reject) => {
     userReq.on('data', (chunk) => {
       reqBodyString += chunk;
     });
@@ -37,37 +38,16 @@ export default async function graphqlProxy(
         // we can just continue and attempt to pass the string
       }
 
-      let status = 200;
-      let body: unknown = '';
-
       try {
         const options = {
           data: reqBodyObject ? reqBodyObject : reqBodyString,
         };
         const client = new GraphqlClient(shopName, token);
         const response = await client.query(options);
-        body = response.body;
+        return resolve(response);
       } catch (err) {
-        switch (err.constructor.name) {
-          case 'MissingRequiredArgument':
-            status = 400;
-            break;
-          case 'HttpResponseError':
-            status = err.code;
-            break;
-          case 'HttpThrottlingError':
-            status = 429;
-            break;
-          default:
-            status = 500;
-        }
-        body = err.message;
-      } finally {
-        userRes.statusCode = status;
-        userRes.end(JSON.stringify(body));
+        return reject(err);
       }
-      return resolve();
     });
   });
-  return promise;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

We noticed that the way the GraphQL proxy currently works is inconsistent with how the webhook `process` method works - while the webhook method returned the result of its operation, the proxy was triggering the actual response to be sent to the client, which was quite confusing.

### WHAT is this pull request doing?

Changing the GraphQL proxy so it behaves consistently by returning the response of the queried request to the app, rather than taking over and responding to the request itself.

This allows apps to take the body of a proxied request and 1) respond however they prefer; 2) run any code they need to after sending the request.

## Type of change

- [X] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
