### PR TITLE
add debugging info when webhook hmac fails to validate (#320)

### DIFF
--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -413,6 +413,7 @@ const WebhooksRegistry: RegistryInterface = {
           responseError = new ShopifyErrors.InvalidWebhookError(
             `Could not validate request for topic ${topic}`,
           );
+          console.log('reqBody', reqBody,'\n generatedHash', generatedHash, '\n hmac', hmac);
         }
 
         response.writeHead(statusCode, headers);


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

1st step to fix #320

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

When a webhook hmac validation fails, show useful debugging info.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

These are not needed:
- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
