### PR TITLE
Include response information in HTTP errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- ⚠️ [Breaking] Instances of `HttpResponseError` now take in a hash of values, and will always include the response code, body (as a string if the response is not JSON), and headers
 - ⚠️ [Breaking] Update supported Admin API versions [#310](https://github.com/Shopify/shopify-node-api/pull/310)
 - Allow full paths in REST requests [#301](https://github.com/Shopify/shopify-node-api/pull/301)
 
@@ -17,17 +18,17 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - ⚠️ [Breaking] Stop responding to the request in the GraphQL Proxy function, returning Shopify's response instead [#312](https://github.com/Shopify/shopify-node-api/pull/312)
 
   The examples below are in [express](https://expressjs.com/); you will now need to handle the response yourself.
-  
+
   Before:
-  
+
   ```js
   app.post('/graphql', async (req, res) => {
     await Shopify.Utils.graphqlProxy(req, res);
   });
   ```
-  
+
   After:
-  
+
   ```js
   app.post('/graphql', async (req, res) => {
     const response = await Shopify.Utils.graphqlProxy(req, res);

--- a/src/base-rest-resource.ts
+++ b/src/base-rest-resource.ts
@@ -144,11 +144,11 @@ class Base {
       }
     } catch (error) {
       if (error instanceof HttpResponseError) {
-        throw new RestResourceRequestError(
-          error.message,
-          error.code,
-          error.statusText,
-        );
+        throw new RestResourceRequestError({
+          message: error.message,
+          code: error.code,
+          statusText: error.statusText,
+        });
       } else {
         throw error;
       }

--- a/src/clients/http_client/__tests__/http_client.test.ts
+++ b/src/clients/http_client/__tests__/http_client.test.ts
@@ -779,6 +779,85 @@ describe('HTTP client', () => {
       query: encodeURI('array[]=a&array[]=b&array[]=c&hash[a]=b&hash[c]=d'),
     }).toMatchMadeHttpRequest();
   });
+
+  it('throws exceptions with response details on internal errors', async () => {
+    const client = new HttpClient(domain);
+
+    fetchMock.mockResponse(JSON.stringify({errors: 'Error 500'}), {
+      status: 500,
+      statusText: 'Error 500',
+      headers: {'X-Text-Header': 'Error 500'},
+    });
+
+    const expectedError = await expect(client.get({path: '/url/path'})).rejects;
+    expectedError.toBeInstanceOf(ShopifyErrors.HttpInternalError);
+    expectedError.toBeInstanceOf(ShopifyErrors.HttpResponseError);
+    expectedError.toMatchObject({
+      body: {errors: 'Error 500'},
+      code: 500,
+      statusText: 'Error 500',
+      headers: {'X-Text-Header': ['Error 500']},
+    });
+  });
+
+  it('throws exceptions with response details on throttled requests', async () => {
+    const client = new HttpClient(domain);
+
+    fetchMock.mockResponse(JSON.stringify({errors: 'Error 429'}), {
+      status: 429,
+      statusText: 'Error 429',
+      headers: {'X-Text-Header': 'Error 429', 'Retry-After': '100'},
+    });
+
+    const expectedError = await expect(client.get({path: '/url/path'})).rejects;
+    expectedError.toBeInstanceOf(ShopifyErrors.HttpThrottlingError);
+    expectedError.toBeInstanceOf(ShopifyErrors.HttpResponseError);
+    expectedError.toMatchObject({
+      body: {errors: 'Error 429'},
+      code: 429,
+      statusText: 'Error 429',
+      headers: {'X-Text-Header': ['Error 429'], 'Retry-After': ['100']},
+      retryAfter: 100,
+    });
+  });
+
+  it('throws exceptions with response details on any other errors', async () => {
+    const client = new HttpClient(domain);
+
+    fetchMock.mockResponse(JSON.stringify({errors: 'Error 403'}), {
+      status: 403,
+      statusText: 'Error 403',
+      headers: {'X-Text-Header': 'Error 403'},
+    });
+
+    const expectedError = await expect(client.get({path: '/url/path'})).rejects;
+    expectedError.toBeInstanceOf(ShopifyErrors.HttpResponseError);
+    expectedError.toMatchObject({
+      body: {errors: 'Error 403'},
+      code: 403,
+      statusText: 'Error 403',
+      headers: {'X-Text-Header': ['Error 403']},
+    });
+  });
+
+  it('throws exceptions with string body', async () => {
+    const client = new HttpClient(domain);
+
+    fetchMock.mockResponse("This isn't JSON!", {
+      status: 404,
+      statusText: 'Error 404',
+      headers: {'X-Text-Header': 'Error 404'},
+    });
+
+    const expectedError = await expect(client.get({path: '/url/path'})).rejects;
+    expectedError.toBeInstanceOf(ShopifyErrors.HttpResponseError);
+    expectedError.toMatchObject({
+      body: "This isn't JSON!",
+      code: 404,
+      statusText: 'Error 404',
+      headers: {'X-Text-Header': ['Error 404']},
+    });
+  });
 });
 
 function setRestClientRetryTime(time: number) {

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,75 +1,74 @@
-class ShopifyError extends Error {
+export class ShopifyError extends Error {
   constructor(...args: any) {
     super(...args);
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }
 
-class InvalidHmacError extends ShopifyError {}
-class InvalidShopError extends ShopifyError {}
-class InvalidJwtError extends ShopifyError {}
-class MissingJwtTokenError extends ShopifyError {}
+export class InvalidHmacError extends ShopifyError {}
+export class InvalidShopError extends ShopifyError {}
+export class InvalidJwtError extends ShopifyError {}
+export class MissingJwtTokenError extends ShopifyError {}
 
-class SafeCompareError extends ShopifyError {}
-class UninitializedContextError extends ShopifyError {}
-class PrivateAppError extends ShopifyError {}
+export class SafeCompareError extends ShopifyError {}
+export class UninitializedContextError extends ShopifyError {}
+export class PrivateAppError extends ShopifyError {}
 
-class HttpRequestError extends ShopifyError {}
-class HttpMaxRetriesError extends ShopifyError {}
-class HttpResponseError extends ShopifyError {
-  public constructor(
-    message: string,
-    readonly code: number,
-    readonly statusText: string,
-  ) {
+export class HttpRequestError extends ShopifyError {}
+export class HttpMaxRetriesError extends ShopifyError {}
+
+interface HttpResponseErrorParams {
+  message: string;
+  code: number;
+  statusText: string;
+  body?: string | {[key: string]: unknown};
+  headers?: {[key: string]: unknown};
+}
+export class HttpResponseError extends ShopifyError {
+  readonly code: number;
+  readonly statusText: string;
+  readonly body?: string | {[key: string]: unknown};
+  readonly headers?: {[key: string]: unknown};
+
+  public constructor({
+    message,
+    code,
+    statusText,
+    body,
+    headers,
+  }: HttpResponseErrorParams) {
     super(message);
+    this.code = code;
+    this.statusText = statusText;
+    this.body = body;
+    this.headers = headers;
   }
 }
-class HttpRetriableError extends ShopifyError {}
-class HttpInternalError extends HttpRetriableError {}
-class HttpThrottlingError extends HttpRetriableError {
-  public constructor(message: string, readonly retryAfter?: number) {
-    super(message);
+export class HttpRetriableError extends HttpResponseError {}
+export class HttpInternalError extends HttpRetriableError {}
+
+interface HttpThrottlingErrorParams extends HttpResponseErrorParams {
+  retryAfter?: number;
+}
+export class HttpThrottlingError extends HttpRetriableError {
+  readonly retryAfter?: number;
+
+  public constructor({retryAfter, ...params}: HttpThrottlingErrorParams) {
+    super(params);
+    this.retryAfter = retryAfter;
   }
 }
 
-class RestResourceError extends ShopifyError {}
-class RestResourceRequestError extends HttpResponseError {}
+export class RestResourceError extends ShopifyError {}
+export class RestResourceRequestError extends HttpResponseError {}
 
-class InvalidOAuthError extends ShopifyError {}
-class SessionNotFound extends ShopifyError {}
-class CookieNotFound extends ShopifyError {}
-class InvalidSession extends ShopifyError {}
+export class InvalidOAuthError extends ShopifyError {}
+export class SessionNotFound extends ShopifyError {}
+export class CookieNotFound extends ShopifyError {}
+export class InvalidSession extends ShopifyError {}
 
-class InvalidWebhookError extends ShopifyError {}
-class SessionStorageError extends ShopifyError {}
+export class InvalidWebhookError extends ShopifyError {}
+export class SessionStorageError extends ShopifyError {}
 
-class MissingRequiredArgument extends ShopifyError {}
-class UnsupportedClientType extends ShopifyError {}
-
-export {
-  ShopifyError,
-  InvalidHmacError,
-  InvalidShopError,
-  InvalidJwtError,
-  MissingJwtTokenError,
-  SafeCompareError,
-  HttpRequestError,
-  HttpMaxRetriesError,
-  HttpResponseError,
-  HttpRetriableError,
-  HttpInternalError,
-  HttpThrottlingError,
-  RestResourceError,
-  RestResourceRequestError,
-  UninitializedContextError,
-  InvalidOAuthError,
-  SessionNotFound,
-  CookieNotFound,
-  InvalidSession,
-  InvalidWebhookError,
-  MissingRequiredArgument,
-  UnsupportedClientType,
-  SessionStorageError,
-  PrivateAppError,
-};
+export class MissingRequiredArgument extends ShopifyError {}
+export class UnsupportedClientType extends ShopifyError {}


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, our error handling for HTTP requests properly handles the response, but it fails to include the information it parsed in the errors, which makes it harder for apps to process the errors e.g. to display error messages back to the user.

### WHAT is this pull request doing?

It adds a few values to all flavours of the `HttpResponseError` objects which should hopefully make it easier for apps to deal with failed requests:

- `code`
- `statusText`
- `body`: a parsed JSON object, or a string if that fails
- `headers`: currently the raw node-fetch headers

This is a breaking change because, in the rare case where an app is manually creating one of these objects, it'll now need to start doing that with an object of arguments, instead of separate arguments. These errors should only ever be created by the library itself, though by exporting them we make it possible for apps to create their own instances.

## Type of change

- [X] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
