### PR TITLE
Add regex to shop validator to support Spin urls

### DIFF
--- a/src/utils/__tests__/shop-validator.test.ts
+++ b/src/utils/__tests__/shop-validator.test.ts
@@ -23,3 +23,27 @@ test("returns false for invalid shop urls, even if they contain the string 'mysh
   const shopUrl = 'notshopify.myshopify.io.org/potato';
   expect(validateShop(shopUrl)).toBe(false);
 });
+
+test('returns true for spin shop urls', () => {
+  const shopUrlUS = 'shop1.shopify.workspace.namespace.us.spin.dev';
+  const shopUrlAsia = 'shop1.shopify.workspace.namespace.asia.spin.dev';
+  const shopUrlEU = 'shop1.shopify.workspace.namespace.eu.spin.dev';
+  expect(validateShop(shopUrlUS)).toBe(true);
+  expect(validateShop(shopUrlAsia)).toBe(true);
+  expect(validateShop(shopUrlEU)).toBe(true);
+});
+
+test('returns false for missing workspace', () => {
+  const shopUrl = 'shop1.shopify.namespace.us.spin.dev';
+  expect(validateShop(shopUrl)).toBe(false);
+});
+
+test('returns false for missing workspace', () => {
+  const shopUrl = 'shop1.shopify.workspace.us.spin.dev';
+  expect(validateShop(shopUrl)).toBe(false);
+});
+
+test('returns false for wrong region', () => {
+  const shopUrl = 'shop1.shopify.workspace.namespace.ca.spin.dev';
+  expect(validateShop(shopUrl)).toBe(false);
+});

--- a/src/utils/shop-validator.ts
+++ b/src/utils/shop-validator.ts
@@ -4,6 +4,7 @@
  * @param shop Shop url: {shop}.myshopify.com
  */
 export default function validateShop(shop: string): boolean {
-  const shopUrlRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.(com|io)[/]*$/;
+  const shopUrlRegex =
+    /(^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.(com|io)[/]*$|^[a-zA-Z0-9][a-zA-Z0-9-]*\.shopify\.[a-zA-Z0-9][a-zA-Z0-9-]*\.[a-zA-Z0-9][a-zA-Z0-9-]*\.(us|asia|eu)\.spin.dev[/]*$)/;
   return shopUrlRegex.test(shop);
 }

--- a/src/utils/shop-validator.ts
+++ b/src/utils/shop-validator.ts
@@ -4,7 +4,12 @@
  * @param shop Shop url: {shop}.myshopify.com
  */
 export default function validateShop(shop: string): boolean {
-  const shopUrlRegex =
-    /(^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.(com|io)[/]*$|^[a-zA-Z0-9][a-zA-Z0-9-]*\.shopify\.[a-zA-Z0-9][a-zA-Z0-9-]*\.[a-zA-Z0-9][a-zA-Z0-9-]*\.(us|asia|eu)\.spin.dev[/]*$)/;
-  return shopUrlRegex.test(shop);
+  const shopUrlRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]*\.myshopify\.(com|io)[/]*$/;
+  const spinUrlRegex =
+    /^[a-zA-Z0-9][a-zA-Z0-9-]*\.shopify\.[a-zA-Z0-9][a-zA-Z0-9-]*\.[a-zA-Z0-9][a-zA-Z0-9-]*\.(us|asia|eu)\.spin.dev[/]*$/;
+  const combinedRegex = new RegExp(
+    `${shopUrlRegex.source}|${spinUrlRegex.source}`,
+  );
+
+  return combinedRegex.test(shop);
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Currently the shop validator will fail for apps on Spin. 

### WHAT is this pull request doing?

PR is a revival of a previously [closed one](https://github.com/Shopify/shopify-node-api/pull/243) that extends the regex in the shop validator to include Spin-like urls (ie. `shop1.shopify.<workspace>.<namespace>.<region>.spin.dev`).

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
  - Is this a noteworthy enough change to document in the changelog?
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
  - Nothing really to document
