### PR TITLE
Remove unnecessary response arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
   ```js
   app.post('/graphql', async (req, res) => {
-    await Shopify.Utils.graphqlProxy(req, res);
+    await Shopify.Utils.graphqlProxy(req);
   });
   ```
 
@@ -31,7 +31,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
   ```js
   app.post('/graphql', async (req, res) => {
-    const response = await Shopify.Utils.graphqlProxy(req, res);
+    const response = await Shopify.Utils.graphqlProxy(req);
     res.status(200).send(response.body);
   });
   ```

--- a/docs/usage/graphql.md
+++ b/docs/usage/graphql.md
@@ -13,7 +13,7 @@ The `GraphQLClient`'s main method is `query`, which accepts a `GraphQLParams` ob
 
 ```ts
 // Load the current session to get the `accessToken`
-const session = await Shopify.Utils.loadCurrentSession(req, res);
+const session = await Shopify.Utils.loadCurrentSession(req);
 // GraphQLClient takes in the shop url and the accessToken for that shop.
 const client = new Shopify.Clients.Graphql(session.shop, session.accessToken);
 // Use client.query and pass your query as `data`

--- a/docs/usage/oauth.md
+++ b/docs/usage/oauth.md
@@ -145,10 +145,10 @@ You can use the `Shopify.Utils.loadCurrentSession()` method to load an online se
 
 As mentioned in the previous sections, you can use the OAuth methods to create both offline and online sessions. Once the process is completed, the session will be stored as per your `Context.SESSION_STORAGE` strategy, and can be retrieved with the below utitilies.
 
-- To load a session, you can use the following method. You can load both online and offline sessions from the current request / response objects.
+- To load a session, you can use the following method. You can load both online and offline sessions from the current request object.
 
 ```ts
-await Shopify.Utils.loadCurrentSession(request, response, isOnline);
+await Shopify.Utils.loadCurrentSession(request, isOnline);
 ```
 
 - If you need to load a session for a background job, you can get offline sessions directly from the shop.

--- a/docs/usage/rest.md
+++ b/docs/usage/rest.md
@@ -44,7 +44,7 @@ We can run the code below in any endpoint where we have access to the request an
 
 ```ts
 // Load the current session to get the `accessToken`.
-const session = await Shopify.Utils.loadCurrentSession(req, res);
+const session = await Shopify.Utils.loadCurrentSession(req);
 // Create a new client for the specified shop.
 const client = new Shopify.Clients.Rest(session.shop, session.accessToken);
 // Use `client.get` to request the specified Shopify REST API endpoint, in this case `products`.
@@ -59,7 +59,7 @@ const products = await client.get({
 
 ```ts
 // Load the current session to get the `accessToken`.
-const session = await Shopify.Utils.loadCurrentSession(req, res);
+const session = await Shopify.Utils.loadCurrentSession(req);
 // Create a new client for the specified shop.
 const client = new Shopify.Clients.Rest(session.shop, session.accessToken);
 // Build your post request body.

--- a/docs/usage/storefront.md
+++ b/docs/usage/storefront.md
@@ -35,7 +35,7 @@ Below is an example of how you may query the Storefront API:
 // Load the access token as per instructions above
 const storefrontAccessToken: string;
 // Load the current session
-const session = await Shopify.Utils.loadCurrentSession(req, res);
+const session = await Shopify.Utils.loadCurrentSession(req);
 // StorefrontClient takes in the shop url and the Storefront Access Token for that shop.
 const client = new Shopify.Clients.Storefront(
   session.shop,

--- a/src/auth/oauth/__tests__/oauth.test.ts
+++ b/src/auth/oauth/__tests__/oauth.test.ts
@@ -436,9 +436,8 @@ describe('validateAuthCallback', () => {
         authorization: `Bearer ${token}`,
       },
     } as Request;
-    const jwtRes = {} as Response;
 
-    const currentSession = await loadCurrentSession(jwtReq, jwtRes);
+    const currentSession = await loadCurrentSession(jwtReq);
     expect(currentSession).not.toBe(null);
     expect(currentSession?.id).toEqual(jwtSessionId);
     const jar = currentCookieJar(res);

--- a/src/auth/oauth/oauth.ts
+++ b/src/auth/oauth/oauth.ts
@@ -116,7 +116,7 @@ const ShopifyOAuth = {
       secure: true,
     });
 
-    const sessionCookie = await this.getCookieSessionId(request, response);
+    const sessionCookie = await this.getCookieSessionId(request);
     if (!sessionCookie) {
       throw new ShopifyErrors.CookieNotFound(
         `Cannot complete OAuth process. Could not find an OAuth cookie for shop url: ${query.shop}`,
@@ -216,13 +216,9 @@ const ShopifyOAuth = {
    * Loads the current session id from the session cookie.
    *
    * @param request HTTP request object
-   * @param response HTTP response object
    */
-  getCookieSessionId(
-    request: Request,
-    response: Response,
-  ): Promise<string | undefined> {
-    const cookies = new Cookies(request, response, {
+  getCookieSessionId(request: Request): Promise<string | undefined> {
+    const cookies = new Cookies(request, {} as Response, {
       secure: true,
       keys: [Context.API_SECRET_KEY],
     });
@@ -252,12 +248,10 @@ const ShopifyOAuth = {
    * Extracts the current session id from the request / response pair.
    *
    * @param request  HTTP request object
-   * @param response HTTP response object
    * @param isOnline Whether to load online (default) or offline sessions (optional)
    */
   async getCurrentSessionId(
     request: Request,
-    response: Response,
     isOnline = true,
   ): Promise<string | undefined> {
     let currentSessionId: string | undefined;
@@ -287,7 +281,7 @@ const ShopifyOAuth = {
     // JWT.
     if (!currentSessionId) {
       // We still want to get the offline session id from the cookie to make sure it's validated
-      currentSessionId = await this.getCookieSessionId(request, response);
+      currentSessionId = await this.getCookieSessionId(request);
     }
 
     return currentSessionId;

--- a/src/utils/__tests__/delete-current-session.test.ts
+++ b/src/utils/__tests__/delete-current-session.test.ts
@@ -47,7 +47,6 @@ describe('deleteCurrenSession', () => {
         Context.API_SECRET_KEY,
       ),
     } as any as Request;
-    const res = {} as Response;
 
     const session = new Session(
       sessionId,
@@ -59,8 +58,8 @@ describe('deleteCurrenSession', () => {
       Context.SESSION_STORAGE.storeSession(session),
     ).resolves.toEqual(true);
 
-    await expect(deleteCurrentSession(req, res)).resolves.toBe(true);
-    await expect(loadCurrentSession(req, res)).resolves.toBe(undefined);
+    await expect(deleteCurrentSession(req)).resolves.toBe(true);
+    await expect(loadCurrentSession(req)).resolves.toBe(undefined);
   });
 
   it('finds and deletes the current session when using JWT', async () => {
@@ -73,7 +72,6 @@ describe('deleteCurrenSession', () => {
         authorization: `Bearer ${token}`,
       },
     } as any as Request;
-    const res = {} as Response;
 
     const session = new Session(
       `test-shop.myshopify.io_${jwtPayload.sub}`,
@@ -85,8 +83,8 @@ describe('deleteCurrenSession', () => {
       Context.SESSION_STORAGE.storeSession(session),
     ).resolves.toEqual(true);
 
-    await expect(deleteCurrentSession(req, res)).resolves.toBe(true);
-    await expect(loadCurrentSession(req, res)).resolves.toBe(undefined);
+    await expect(deleteCurrentSession(req)).resolves.toBe(true);
+    await expect(loadCurrentSession(req)).resolves.toBe(undefined);
   });
 
   it('finds and deletes the current offline session when using cookies', async () => {
@@ -102,7 +100,6 @@ describe('deleteCurrenSession', () => {
         Context.API_SECRET_KEY,
       ),
     } as any as Request;
-    const res = {} as Response;
 
     const session = new Session(
       sessionId,
@@ -114,8 +111,8 @@ describe('deleteCurrenSession', () => {
       Context.SESSION_STORAGE.storeSession(session),
     ).resolves.toEqual(true);
 
-    await expect(deleteCurrentSession(req, res, false)).resolves.toBe(true);
-    await expect(loadCurrentSession(req, res, false)).resolves.toBe(undefined);
+    await expect(deleteCurrentSession(req, false)).resolves.toBe(true);
+    await expect(loadCurrentSession(req, false)).resolves.toBe(undefined);
   });
 
   it('finds and deletes the current offline session when using JWT', async () => {
@@ -128,7 +125,6 @@ describe('deleteCurrenSession', () => {
         authorization: `Bearer ${token}`,
       },
     } as any as Request;
-    const res = {} as Response;
 
     const session = new Session(
       ShopifyOAuth.getOfflineSessionId('test-shop.myshopify.io'),
@@ -140,8 +136,8 @@ describe('deleteCurrenSession', () => {
       Context.SESSION_STORAGE.storeSession(session),
     ).resolves.toEqual(true);
 
-    await expect(deleteCurrentSession(req, res, false)).resolves.toBe(true);
-    await expect(loadCurrentSession(req, res, false)).resolves.toBe(undefined);
+    await expect(deleteCurrentSession(req, false)).resolves.toBe(true);
+    await expect(loadCurrentSession(req, false)).resolves.toBe(undefined);
   });
 
   it('throws an error when no cookie is found', async () => {
@@ -149,9 +145,8 @@ describe('deleteCurrenSession', () => {
     Context.initialize(Context);
 
     const req = {} as Request;
-    const res = {} as Response;
 
-    await expect(() => deleteCurrentSession(req, res)).rejects.toBeInstanceOf(
+    await expect(() => deleteCurrentSession(req)).rejects.toBeInstanceOf(
       Shopify.Errors.SessionNotFound,
     );
   });
@@ -165,9 +160,8 @@ describe('deleteCurrenSession', () => {
         authorization: "What's a bearer token?",
       },
     } as any as Request;
-    const res = {} as Response;
 
-    await expect(() => deleteCurrentSession(req, res)).rejects.toBeInstanceOf(
+    await expect(() => deleteCurrentSession(req)).rejects.toBeInstanceOf(
       Shopify.Errors.MissingJwtTokenError,
     );
   });

--- a/src/utils/__tests__/graphql_proxy.test.ts
+++ b/src/utils/__tests__/graphql_proxy.test.ts
@@ -55,10 +55,7 @@ describe('GraphQL proxy with session', () => {
         statusCode: 200,
         statusText: 'OK',
       } as Response;
-      const response = await graphqlProxy(
-        await convertRequest(req),
-        internalResponse,
-      );
+      const response = await graphqlProxy(await convertRequest(req));
       internalResponse.body = JSON.stringify(response.body);
       convertResponse(internalResponse, res);
     } catch (err) {
@@ -147,7 +144,6 @@ describe('GraphQL proxy', () => {
         authorization: `Bearer ${token}`,
       },
     } as any as Request;
-    const res = {} as Response;
     const session = new Session(
       `test-shop.myshopify.io_${jwtPayload.sub}`,
       shop,
@@ -156,13 +152,12 @@ describe('GraphQL proxy', () => {
     );
     Context.SESSION_STORAGE.storeSession(session);
 
-    await expect(graphqlProxy(req, res)).rejects.toThrow(InvalidSession);
+    await expect(graphqlProxy(req)).rejects.toThrow(InvalidSession);
   });
 
   it('throws an error if no session', async () => {
     const req = {headers: {}} as Request;
-    const res = {} as Response;
-    await expect(graphqlProxy(req, res)).rejects.toThrow(SessionNotFound);
+    await expect(graphqlProxy(req)).rejects.toThrow(SessionNotFound);
   });
 });
 

--- a/src/utils/__tests__/load-current-session.test.ts
+++ b/src/utils/__tests__/load-current-session.test.ts
@@ -47,7 +47,6 @@ describe('loadCurrentSession', () => {
         Context.API_SECRET_KEY,
       ),
     } as Request;
-    const res = {} as Response;
 
     const session = new Session(
       sessionId,
@@ -59,7 +58,7 @@ describe('loadCurrentSession', () => {
       Context.SESSION_STORAGE.storeSession(session),
     ).resolves.toEqual(true);
 
-    await expect(loadCurrentSession(req, res)).resolves.toEqual(session);
+    await expect(loadCurrentSession(req)).resolves.toEqual(session);
   });
 
   it('loads nothing if there is no session for non-embedded apps', async () => {
@@ -67,9 +66,8 @@ describe('loadCurrentSession', () => {
     Context.initialize(Context);
 
     const req = {} as Request;
-    const res = {} as Response;
 
-    await expect(loadCurrentSession(req, res)).resolves.toBeUndefined();
+    await expect(loadCurrentSession(req)).resolves.toBeUndefined();
   });
 
   it('gets the current session from JWT token for embedded apps', async () => {
@@ -82,7 +80,6 @@ describe('loadCurrentSession', () => {
         authorization: `Bearer ${token}`,
       },
     } as any as Request;
-    const res = {} as Response;
 
     const session = new Session(
       `test-shop.myshopify.io_${jwtPayload.sub}`,
@@ -94,7 +91,7 @@ describe('loadCurrentSession', () => {
       Context.SESSION_STORAGE.storeSession(session),
     ).resolves.toEqual(true);
 
-    await expect(loadCurrentSession(req, res)).resolves.toEqual(session);
+    await expect(loadCurrentSession(req)).resolves.toEqual(session);
   });
 
   it('loads nothing if no authorization header is present', async () => {
@@ -102,9 +99,8 @@ describe('loadCurrentSession', () => {
     Context.initialize(Context);
 
     const req = {headers: {}} as Request;
-    const res = {} as Response;
 
-    await expect(loadCurrentSession(req, res)).resolves.toBeUndefined();
+    await expect(loadCurrentSession(req)).resolves.toBeUndefined();
   });
 
   it('loads nothing if there is no session for embedded apps', async () => {
@@ -117,9 +113,8 @@ describe('loadCurrentSession', () => {
         authorization: `Bearer ${token}`,
       },
     } as any as Request;
-    const res = {} as Response;
 
-    await expect(loadCurrentSession(req, res)).resolves.toBeUndefined();
+    await expect(loadCurrentSession(req)).resolves.toBeUndefined();
   });
 
   it('fails if authorization header is missing or is not a Bearer token', async () => {
@@ -131,9 +126,8 @@ describe('loadCurrentSession', () => {
         authorization: 'Not a Bearer token!',
       },
     } as any as Request;
-    const res = {} as Response;
 
-    await expect(() => loadCurrentSession(req, res)).rejects.toBeInstanceOf(
+    await expect(() => loadCurrentSession(req)).rejects.toBeInstanceOf(
       Shopify.Errors.MissingJwtTokenError,
     );
   });
@@ -149,7 +143,6 @@ describe('loadCurrentSession', () => {
         ...(await createSessionCookieHeader(sessionId, Context.API_SECRET_KEY)),
       },
     } as any as Request;
-    const res = {} as Response;
 
     const session = new Session(
       sessionId,
@@ -161,7 +154,7 @@ describe('loadCurrentSession', () => {
       Context.SESSION_STORAGE.storeSession(session),
     ).resolves.toEqual(true);
 
-    await expect(loadCurrentSession(req, res)).resolves.toEqual(session);
+    await expect(loadCurrentSession(req)).resolves.toEqual(session);
   });
 
   it('loads offline sessions from cookies', async () => {
@@ -177,7 +170,6 @@ describe('loadCurrentSession', () => {
         Context.API_SECRET_KEY,
       ),
     } as Request;
-    const res = {} as Response;
 
     const session = new Session(
       sessionId,
@@ -189,7 +181,7 @@ describe('loadCurrentSession', () => {
       Context.SESSION_STORAGE.storeSession(session),
     ).resolves.toEqual(true);
 
-    await expect(loadCurrentSession(req, res, false)).resolves.toEqual(session);
+    await expect(loadCurrentSession(req, false)).resolves.toEqual(session);
   });
 
   it('loads offline sessions from JWT token', async () => {
@@ -202,7 +194,6 @@ describe('loadCurrentSession', () => {
         authorization: `Bearer ${token}`,
       },
     } as any as Request;
-    const res = {} as Response;
 
     const session = new Session(
       ShopifyOAuth.getOfflineSessionId('test-shop.myshopify.io'),
@@ -214,7 +205,7 @@ describe('loadCurrentSession', () => {
       Context.SESSION_STORAGE.storeSession(session),
     ).resolves.toEqual(true);
 
-    await expect(loadCurrentSession(req, res, false)).resolves.toEqual(session);
+    await expect(loadCurrentSession(req, false)).resolves.toEqual(session);
   });
 });
 

--- a/src/utils/__tests__/store-session.test.ts
+++ b/src/utils/__tests__/store-session.test.ts
@@ -1,8 +1,4 @@
-import {
-  setAbstractFetchFunc,
-  Request,
-  Response,
-} from '../../adapters/abstract-http';
+import {setAbstractFetchFunc, Request} from '../../adapters/abstract-http';
 import * as mockAdapter from '../../adapters/mock-adapter';
 import {Session} from '../../auth/session';
 import {Context} from '../../context';
@@ -35,7 +31,6 @@ describe('storeSession', () => {
         authorization: `Bearer ${token}`,
       },
     } as any as Request;
-    const res = {} as Response;
 
     const session = new Session(
       `test-shop.myshopify.io_${jwtPayload.sub}`,
@@ -45,13 +40,13 @@ describe('storeSession', () => {
     );
     await storeSession(session);
 
-    let loadedSession = await loadCurrentSession(req, res);
+    let loadedSession = await loadCurrentSession(req);
     expect(loadedSession).toEqual(session);
 
     session.state = 'new_state';
     await storeSession(session);
 
-    loadedSession = await loadCurrentSession(req, res);
+    loadedSession = await loadCurrentSession(req);
     expect(loadedSession).toEqual(session);
   });
 });

--- a/src/utils/__tests__/with-session.test.ts
+++ b/src/utils/__tests__/with-session.test.ts
@@ -48,13 +48,12 @@ describe('withSession', () => {
 
   it('throws an error when there is no session matching the params requested', async () => {
     const req = {} as Request;
-    const res = {} as Response;
 
     await expect(
       withSession({clientType: 'rest', isOnline: false, shop}),
     ).rejects.toThrow(Shopify.Errors.SessionNotFound);
     await expect(
-      withSession({clientType: 'graphql', isOnline: true, req, res}),
+      withSession({clientType: 'graphql', isOnline: true, req}),
     ).rejects.toThrowError(Shopify.Errors.SessionNotFound);
   });
 
@@ -110,13 +109,11 @@ describe('withSession', () => {
         Context.API_SECRET_KEY,
       ),
     } as any as Request;
-    const res = {} as Response;
 
     const restRequestCtx = (await withSession({
       clientType: 'rest',
       isOnline: true,
       req,
-      res,
     })) as RestWithSession;
 
     expect(restRequestCtx).toBeDefined();
@@ -127,7 +124,6 @@ describe('withSession', () => {
       clientType: 'graphql',
       isOnline: true,
       req,
-      res,
     })) as GraphqlWithSession;
 
     expect(gqlRequestCtx).toBeDefined();
@@ -163,13 +159,11 @@ describe('withSession', () => {
         authorization: `Bearer ${token}`,
       },
     } as any as Request;
-    const res = {} as Response;
 
     const restRequestCtx = (await withSession({
       clientType: 'rest',
       isOnline: true,
       req,
-      res,
     })) as RestWithSession;
 
     expect(restRequestCtx).toBeDefined();
@@ -180,7 +174,6 @@ describe('withSession', () => {
       clientType: 'graphql',
       isOnline: true,
       req,
-      res,
     })) as GraphqlWithSession;
 
     expect(gqlRequestCtx).toBeDefined();

--- a/src/utils/delete-current-session.ts
+++ b/src/utils/delete-current-session.ts
@@ -1,27 +1,21 @@
-import {Request, Response} from '../adapters/abstract-http';
+import {Request} from '../adapters/abstract-http';
 import {Context} from '../context';
 import {ShopifyOAuth} from '../auth/oauth/oauth';
 import * as ShopifyErrors from '../error';
 
 /**
- * Finds and deletes the current user's session, based on the given request and response
+ * Finds and deletes the current user's session, based on the given request
  *
  * @param request  Current HTTP request
- * @param response Current HTTP response
  * @param isOnline Whether to load online (default) or offline sessions (optional)
  */
 export default async function deleteCurrentSession(
   request: Request,
-  response: Response,
   isOnline = true,
 ): Promise<boolean | never> {
   Context.throwIfUninitialized();
 
-  const sessionId = await ShopifyOAuth.getCurrentSessionId(
-    request,
-    response,
-    isOnline,
-  );
+  const sessionId = await ShopifyOAuth.getCurrentSessionId(request, isOnline);
   if (!sessionId) {
     throw new ShopifyErrors.SessionNotFound('No active session found.');
   }

--- a/src/utils/graphql_proxy.ts
+++ b/src/utils/graphql_proxy.ts
@@ -1,4 +1,4 @@
-import {Request, Response} from '../adapters/abstract-http';
+import {Request} from '../adapters/abstract-http';
 import {GraphqlClient} from '../clients/graphql';
 import {RequestReturn} from '../clients/http_client/types';
 import * as ShopifyErrors from '../error';
@@ -7,9 +7,8 @@ import loadCurrentSession from './load-current-session';
 
 export default async function graphqlProxy(
   userReq: Request,
-  userRes: Response,
 ): Promise<RequestReturn> {
-  const session = await loadCurrentSession(userReq, userRes);
+  const session = await loadCurrentSession(userReq);
   if (!session) {
     throw new ShopifyErrors.SessionNotFound(
       'Cannot proxy query. No session found.',

--- a/src/utils/load-current-session.ts
+++ b/src/utils/load-current-session.ts
@@ -1,27 +1,21 @@
-import {Request, Response} from '../adapters/abstract-http';
+import {Request} from '../adapters/abstract-http';
 import {Context} from '../context';
 import {ShopifyOAuth} from '../auth/oauth/oauth';
 import {Session} from '../auth/session';
 
 /**
- * Loads the current user's session, based on the given request and response.
+ * Loads the current user's session, based on the given request.
  *
  * @param request  Current HTTP request
- * @param response Current HTTP response
  * @param isOnline Whether to load online (default) or offline sessions (optional)
  */
 export default async function loadCurrentSession(
   request: Request,
-  response: Response,
   isOnline = true,
 ): Promise<Session | undefined> {
   Context.throwIfUninitialized();
 
-  const sessionId = await ShopifyOAuth.getCurrentSessionId(
-    request,
-    response,
-    isOnline,
-  );
+  const sessionId = await ShopifyOAuth.getCurrentSessionId(request, isOnline);
   if (!sessionId) {
     return Promise.resolve(undefined);
   }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,4 @@
-import {Request, Response} from '../adapters/abstract-http';
+import {Request} from '../adapters/abstract-http';
 import {Session} from '../auth/session';
 import {GraphqlClient} from '../clients/graphql';
 import {RestClient} from '../clients/rest';
@@ -7,7 +7,6 @@ export interface WithSessionParams {
   clientType: 'rest' | 'graphql';
   isOnline: boolean;
   req?: Request;
-  res?: Response;
   shop?: string;
 }
 

--- a/src/utils/with-session.ts
+++ b/src/utils/with-session.ts
@@ -12,20 +12,19 @@ export default async function withSession({
   clientType,
   isOnline,
   req,
-  res,
   shop,
 }: WithSessionParams): Promise<WithSessionResponse> {
   Context.throwIfUninitialized();
 
   let session: Session | undefined;
   if (isOnline) {
-    if (!req || !res) {
+    if (!req) {
       throw new ShopifyErrors.MissingRequiredArgument(
-        'Please pass in both the "request" and "response" objects.',
+        'Please pass in both the "request" object.',
       );
     }
 
-    session = await loadCurrentSession(req, res);
+    session = await loadCurrentSession(req);
   } else {
     if (!shop) {
       throw new ShopifyErrors.MissingRequiredArgument(

--- a/src/utils/with-session.ts
+++ b/src/utils/with-session.ts
@@ -20,7 +20,7 @@ export default async function withSession({
   if (isOnline) {
     if (!req) {
       throw new ShopifyErrors.MissingRequiredArgument(
-        'Please pass in both the "request" object.',
+        'Please pass in the "request" object.',
       );
     }
 


### PR DESCRIPTION
We don't need to pass in the response when grabbing the current session id from the headers (cookie / auth). This PR drops that argument and refactors calls up the chain (which turned out to be quite a few).