### PR TITLE
Add test for loading unknown attributes

### DIFF
--- a/src/__tests__/base-rest-resource.test.ts
+++ b/src/__tests__/base-rest-resource.test.ts
@@ -226,6 +226,19 @@ describe('Base REST resource', () => {
     }).toMatchMadeHttpRequest();
   });
 
+  it('loads unknown attribute', async () => {
+    const responseBody = {
+      fake_resource: {attribute: 'attribute', 'unknown?': 'some-value'},
+    };
+    fetchMock.mockResponseOnce(JSON.stringify(responseBody));
+
+    const got = await FakeResource.find({id: 1, session} as any);
+
+    expect(got!.attribute).toEqual('attribute');
+    expect(got!['unknown?']).toEqual('some-value');
+    expect(got!.serialize()['unknown?']).toEqual('some-value');
+  });
+
   it('saves with unknown attribute', async () => {
     const expectedRequestBody = {fake_resource: {unknown: 'some-value'}};
     fetchMock.mockResponseOnce(JSON.stringify({}));


### PR DESCRIPTION
### WHY are these changes introduced?

Sometimes, the API will send back data that's not exactly as documented, such as the `optionX` fields in products / variants - those are documented as `option`, but they dynamically accept any number of options. This PR is just helping make sure we don't get any regressions in that sense.

### WHAT is this pull request doing?

Ensuring we're properly loading unknown attributes from the API response by adding a new unit test for that case.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added/updated tests for this change
