### PR TITLE
Fixes issue 363 - provides error for GDPR topics during registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+- Fixes [#363](https://github.com/Shopify/shopify-node-api/issues/363)
+  - Webhooks `register` now checks for any attempt to register a GDPR topic (not done via API but by Partner Dashboard), provides an error message in response
+  - For topics that don't exist, `register` checks the response from the initial API call for an `errors` field and returns accordingly
+
 ## [3.0.1] - 2022-04-11
 
 ### Added


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes issue #363

For the mandatory GDPR webhooks, there's no registration via API (it's done via Partner Dashboard) hence there's no corresponding values for the associated GDPR topics.

`register` first checks to see if there's an existing registration but fails to confirm that the response is valid and just assumes there's a `data` key in the response.  This trips up the registration for the GDPR topics as well as any other invalid topic, e.g., "NONSENSE_TOPIC".

### WHAT is this pull request doing?

1. for GDPR topics (_CUSTOMERS_DATA_REQUEST_, _CUSTOMERS_REDACT_, _SHOP_REDACT_), the `register` method short-circuits any API calls and returns an error with a (hopefully!) useful message.
2. for topics that don't exist, the `register` method now examines the response from the initial checking API call for an `errors` key and returns if there is one (copying the `errors` key to the response).

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs) - **not applicable**
