### PR TITLE
Adds support for read-only attributes to serialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- Add optional `saving` parameter to `serialize` of `Base` class - default is `false` and will include read-only attributes in returned object; `true` used for `save` when committing via API to Shopify.
+
 ### Fixed
 - Fixes [#363](https://github.com/Shopify/shopify-node-api/issues/363)
   - Webhooks `register` now checks for any attempt to register a GDPR topic (not done via API but by Partner Dashboard), provides an error message in response

--- a/src/auth/session/storage/__tests__/mongodb.test.ts
+++ b/src/auth/session/storage/__tests__/mongodb.test.ts
@@ -15,7 +15,7 @@ const dbName = 'shopitest';
 
 // SORRY NOT SORRY. Docker containers can take quite a while to get ready,
 // especially on CI. This is hopefully enough.
-jest.setTimeout(20000);
+jest.setTimeout(25000);
 
 describe('MongoDBSessionStorage', () => {
   let storage: MongoDBSessionStorage;

--- a/src/auth/session/storage/__tests__/mysql.test.ts
+++ b/src/auth/session/storage/__tests__/mysql.test.ts
@@ -14,7 +14,7 @@ const dbURL = new URL('mysql://shopify:passify@localhost/shopitest');
 
 // SORRY NOT SORRY. Docker containers can take quite a while to get ready,
 // especially on CI. This is hopefully enough.
-jest.setTimeout(20000);
+jest.setTimeout(25000);
 
 describe('MySQLSessionStorage', () => {
   let storage: MySQLSessionStorage;

--- a/src/auth/session/storage/__tests__/postgresql.test.ts
+++ b/src/auth/session/storage/__tests__/postgresql.test.ts
@@ -14,7 +14,7 @@ const dbURL = new URL('postgres://shopify:passify@localhost/shopitest');
 
 // SORRY NOT SORRY. Docker containers can take quite a while to get ready,
 // especially on CI. This is hopefully enough.
-jest.setTimeout(20000);
+jest.setTimeout(25000);
 
 describe('PostgreSQLSessionStorage', () => {
   let storage: PostgreSQLSessionStorage;

--- a/src/auth/session/storage/__tests__/redis.test.ts
+++ b/src/auth/session/storage/__tests__/redis.test.ts
@@ -14,7 +14,7 @@ const dbURL = new URL('redis://shopify:passify@localhost/1');
 
 // SORRY NOT SORRY. Docker containers can take quite a while to get ready,
 // especially on CI. This is hopefully enough.
-jest.setTimeout(20000);
+jest.setTimeout(25000);
 
 describe('RedisSessionStorage', () => {
   let storage: RedisSessionStorage | undefined;


### PR DESCRIPTION
### WHY are these changes introduced?

To align the behaviour of `serialize` with that of the Ruby `to_hash` method, as updated by https://github.com/Shopify/shopify_api/pull/941


### WHAT is this pull request doing?

Previously, `serialize` excluded read-only attributes, since it was assumed it was just being used by `save` method.

Now, default is that `serialize` returns all attributes, and an optional (`saving=`)`true` parameter will exclude them when used inside `save` method.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
