### PR TITLE
[FIX] SQLite bug on custom session storage

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import * as ShopifyErrors from './error';
 import {SessionStorage} from './auth/session/session_storage';
 import {SQLiteSessionStorage} from './auth/session/storage/sqlite';
+import {MemorySessionStorage} from './auth/session';
 import {ApiVersion, ContextParams} from './base-types';
 import {AuthScopes} from './auth/scopes';
 
@@ -43,7 +44,7 @@ const Context: ContextInterface = {
   API_VERSION: ApiVersion.Unstable,
   IS_EMBEDDED_APP: true,
   IS_PRIVATE_APP: false,
-  SESSION_STORAGE: new SQLiteSessionStorage(dbFile),
+  SESSION_STORAGE: new MemorySessionStorage(),
 
   initialize(params: ContextParams): void {
     let scopes: AuthScopes;
@@ -90,6 +91,8 @@ const Context: ContextInterface = {
 
     if (params.SESSION_STORAGE) {
       this.SESSION_STORAGE = params.SESSION_STORAGE;
+    } else {
+      this.SESSION_STORAGE = new SQLiteSessionStorage(dbFile);
     }
 
     if (params.USER_AGENT_PREFIX) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #389 

### WHAT is this pull request doing?

When initializing the `Shopify.Context`, it assigns to create an empty SQLite database to save session details. With the current implementation, even if the end user is using custom session storage implementation, a SQLite database is created in the root of the folder where `Shopify.Context.initialize()` is called, creating a bad developer experience. This PR fixes that issue by first creating a memory based session storage in the init function and later checks if the user is using a custom session storage, and if not, goes ahead with creating a SQLite

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
