### PR TITLE
Augment session data

### DIFF
--- a/src/auth/session/session-utils.ts
+++ b/src/auth/session/session-utils.ts
@@ -42,3 +42,14 @@ export function sessionEntries(
 ): [string, string | number][] {
   return Object.entries(session).filter(([key]) => includedKeys.includes(key));
 }
+
+export function sessionEqual(
+  sessionA: SessionInterface | undefined,
+  sessionB: SessionInterface | undefined,
+): boolean {
+  if (!sessionA) return false;
+  if (!sessionB) return false;
+  const copyA = sessionFromEntries(sessionEntries(sessionA));
+  const copyB = sessionFromEntries(sessionEntries(sessionB));
+  return JSON.stringify(copyA) === JSON.stringify(copyB);
+}

--- a/src/auth/session/session-utils.ts
+++ b/src/auth/session/session-utils.ts
@@ -24,7 +24,7 @@ export function sessionFromEntries(
       })
       // Sanitize values
       .map(([key, value]) => {
-        switch(key) {
+        switch (key) {
           case 'isOnline':
             if (typeof value === 'string') {
               return [key, value.toString().toLowerCase() === 'true'];
@@ -33,15 +33,19 @@ export function sessionFromEntries(
             }
             return [key, value];
           case 'scope':
-            return [key, value.toString()]
+            return [key, value.toString()];
           case 'expires':
             return [key, new Date(Number(value) * 1000)];
           case 'onlineAccessInfo':
-            return [key, {
-              associated_user: {
-                id: Number(value)
-              }
-            }];
+            return [
+              key,
+              {
+                // eslint-disable-next-line  @typescript-eslint/naming-convention
+                associated_user: {
+                  id: Number(value),
+                },
+              },
+            ];
           default:
             return [key, value];
         }
@@ -59,24 +63,26 @@ const includedKeys = [
   'scope',
   'accessToken',
   'expires',
-  'onlineAccessInfo'
+  'onlineAccessInfo',
 ];
 export function sessionEntries(
   session: SessionInterface,
 ): [string, string | number][] {
-  return Object.entries(session)
-    .filter(([key]) => includedKeys.includes(key))
-    // Prepare values for db storage
-    .map(([key, value]) => {
-      switch (key) {
-        case 'expires':
-          return [key, Math.floor(value.getTime() / 1000)];
-        case 'onlineAccessInfo':
-          return [key, value?.associated_user?.id];
-        default:
-          return [key, value];
-      }
-    });
+  return (
+    Object.entries(session)
+      .filter(([key]) => includedKeys.includes(key))
+      // Prepare values for db storage
+      .map(([key, value]) => {
+        switch (key) {
+          case 'expires':
+            return [key, Math.floor(value.getTime() / 1000)];
+          case 'onlineAccessInfo':
+            return [key, value?.associated_user?.id];
+          default:
+            return [key, value];
+        }
+      })
+  );
 }
 
 export function sessionEqual(

--- a/src/auth/session/session-utils.ts
+++ b/src/auth/session/session-utils.ts
@@ -11,6 +11,8 @@ export function sessionFromEntries(
       .filter(([_key, value]) => value !== null)
       .map(([key, value]) => {
         switch (key.toLowerCase()) {
+          case 'expires':
+            return ['expires', new Date(Number(value) * 1000)];
           case 'isonline':
             return ['isOnline', value];
           case 'accesstoken':
@@ -36,11 +38,21 @@ const includedKeys = [
   'isOnline',
   'scope',
   'accessToken',
+  'expires',
 ];
 export function sessionEntries(
   session: SessionInterface,
 ): [string, string | number][] {
-  return Object.entries(session).filter(([key]) => includedKeys.includes(key));
+  return Object.entries(session)
+    .filter(([key]) => includedKeys.includes(key))
+    .map(([key, value]) => {
+      switch (key) {
+        case 'expires':
+          return [key, Math.floor(value.getTime() / 1000)];
+        default:
+          return [key, value];
+      }
+    });
 }
 
 export function sessionEqual(

--- a/src/auth/session/session-utils.ts
+++ b/src/auth/session/session-utils.ts
@@ -35,7 +35,7 @@ export function sessionFromEntries(
           case 'scope':
             return [key, value.toString()];
           case 'expires':
-            return [key, new Date(Number(value) * 1000)];
+            return [key, value ? new Date(Number(value) * 1000) : undefined];
           case 'onlineAccessInfo':
             return [
               key,
@@ -75,7 +75,10 @@ export function sessionEntries(
       .map(([key, value]) => {
         switch (key) {
           case 'expires':
-            return [key, Math.floor(value.getTime() / 1000)];
+            return [
+              key,
+              value ? Math.floor(value.getTime() / 1000) : undefined,
+            ];
           case 'onlineAccessInfo':
             return [key, value?.associated_user?.id];
           default:

--- a/src/auth/session/storage/__tests__/battery-of-tests.ts
+++ b/src/auth/session/storage/__tests__/battery-of-tests.ts
@@ -54,7 +54,8 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
     const storage = await storageFactory();
     const sessionId = 'test_session';
     const session = new Session(sessionId, 'shop', 'state', false);
-    session.onlineAccessInfo = {associated_user: {} } as any;
+    // eslint-disable-next-line  @typescript-eslint/naming-convention
+    session.onlineAccessInfo = {associated_user: {}} as any;
     session.onlineAccessInfo!.associated_user.id = 123;
 
     await expect(storage.storeSession(session)).resolves.toBe(true);

--- a/src/auth/session/storage/__tests__/battery-of-tests.ts
+++ b/src/auth/session/storage/__tests__/battery-of-tests.ts
@@ -7,9 +7,55 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
     const storage = await storageFactory();
     const sessionId = 'test_session';
     const session = new Session(sessionId, 'shop', 'state', false);
+
+    await expect(storage.storeSession(session)).resolves.toBe(true);
+    expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
+      true,
+    );
+
+    await expect(storage.storeSession(session)).resolves.toBe(true);
+    expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
+      true,
+    );
+
+    await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
+    await expect(storage.loadSession(sessionId)).resolves.toBeUndefined();
+
+    // Deleting a non-existing session should work
+    await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
+  });
+
+  it('can store and delete offline sessions with expiry date', async () => {
+    const storage = await storageFactory();
+    const sessionId = 'test_session';
+    const session = new Session(sessionId, 'shop', 'state', false);
     const expiryDate = new Date();
     expiryDate.setMinutes(expiryDate.getMinutes() + 60);
     session.expires = expiryDate;
+
+    await expect(storage.storeSession(session)).resolves.toBe(true);
+    expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
+      true,
+    );
+
+    await expect(storage.storeSession(session)).resolves.toBe(true);
+    expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
+      true,
+    );
+
+    await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
+    await expect(storage.loadSession(sessionId)).resolves.toBeUndefined();
+
+    // Deleting a non-existing session should work
+    await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
+  });
+
+  it('can store and delete offline sessions with user info', async () => {
+    const storage = await storageFactory();
+    const sessionId = 'test_session';
+    const session = new Session(sessionId, 'shop', 'state', false);
+    session.onlineAccessInfo = {associated_user: {} } as any;
+    session.onlineAccessInfo!.associated_user.id = 123;
 
     await expect(storage.storeSession(session)).resolves.toBe(true);
     expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(

--- a/src/auth/session/storage/__tests__/battery-of-tests.ts
+++ b/src/auth/session/storage/__tests__/battery-of-tests.ts
@@ -7,6 +7,9 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
     const storage = await storageFactory();
     const sessionId = 'test_session';
     const session = new Session(sessionId, 'shop', 'state', false);
+    const expiryDate = new Date();
+    expiryDate.setMinutes(expiryDate.getMinutes() + 60);
+    session.expires = expiryDate;
 
     await expect(storage.storeSession(session)).resolves.toBe(true);
     expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(

--- a/src/auth/session/storage/__tests__/battery-of-tests.ts
+++ b/src/auth/session/storage/__tests__/battery-of-tests.ts
@@ -3,76 +3,59 @@ import {sessionEqual} from '../../session-utils';
 import {SessionStorage} from '../../session_storage';
 
 export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
-  it('can store and delete offline sessions', async () => {
-    const storage = await storageFactory();
+  it('can store and delete all kinds of sessions', async () => {
+    const sessionFactories = [
+      async () => {
+        const session = new Session(sessionId, 'shop', 'state', false);
+        return session;
+      },
+      async () => {
+        const session = new Session(sessionId, 'shop', 'state', false);
+        const expiryDate = new Date();
+        expiryDate.setMinutes(expiryDate.getMinutes() + 60);
+        session.expires = expiryDate;
+        return session;
+      },
+      async () => {
+        const session = new Session(sessionId, 'shop', 'state', false);
+        session.expires = null as any;
+        return session;
+      },
+      async () => {
+        const session = new Session(sessionId, 'shop', 'state', false);
+        session.expires = undefined;
+        return session;
+      },
+      async () => {
+        const session = new Session(sessionId, 'shop', 'state', false);
+        // eslint-disable-next-line  @typescript-eslint/naming-convention
+        session.onlineAccessInfo = {associated_user: {}} as any;
+        session.onlineAccessInfo!.associated_user.id = 123;
+        return session;
+      },
+    ];
+
     const sessionId = 'test_session';
-    const session = new Session(sessionId, 'shop', 'state', false);
-
-    await expect(storage.storeSession(session)).resolves.toBe(true);
-    expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
-      true,
-    );
-
-    await expect(storage.storeSession(session)).resolves.toBe(true);
-    expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
-      true,
-    );
-
-    await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
-    await expect(storage.loadSession(sessionId)).resolves.toBeUndefined();
-
-    // Deleting a non-existing session should work
-    await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
-  });
-
-  it('can store and delete offline sessions with expiry date', async () => {
     const storage = await storageFactory();
-    const sessionId = 'test_session';
-    const session = new Session(sessionId, 'shop', 'state', false);
-    const expiryDate = new Date();
-    expiryDate.setMinutes(expiryDate.getMinutes() + 60);
-    session.expires = expiryDate;
+    for (const factory of sessionFactories) {
+      const session = await factory();
 
-    await expect(storage.storeSession(session)).resolves.toBe(true);
-    expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
-      true,
-    );
+      await expect(storage.storeSession(session)).resolves.toBe(true);
+      expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
+        true,
+      );
 
-    await expect(storage.storeSession(session)).resolves.toBe(true);
-    expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
-      true,
-    );
+      await expect(storage.storeSession(session)).resolves.toBe(true);
+      expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
+        true,
+      );
 
-    await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
-    await expect(storage.loadSession(sessionId)).resolves.toBeUndefined();
+      await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
+      await expect(storage.loadSession(sessionId)).resolves.toBeUndefined();
 
-    // Deleting a non-existing session should work
-    await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
-  });
-
-  it('can store and delete offline sessions with user info', async () => {
-    const storage = await storageFactory();
-    const sessionId = 'test_session';
-    const session = new Session(sessionId, 'shop', 'state', false);
-    // eslint-disable-next-line  @typescript-eslint/naming-convention
-    session.onlineAccessInfo = {associated_user: {}} as any;
-    session.onlineAccessInfo!.associated_user.id = 123;
-
-    await expect(storage.storeSession(session)).resolves.toBe(true);
-    expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
-      true,
-    );
-
-    await expect(storage.storeSession(session)).resolves.toBe(true);
-    expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
-      true,
-    );
-
-    await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
-    await expect(storage.loadSession(sessionId)).resolves.toBeUndefined();
-
-    // Deleting a non-existing session should work
-    await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
+      // Deleting a non-existing session should work
+      await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
+    }
   });
 
   it('can store sessions with unexpected fields', async () => {

--- a/src/auth/session/storage/__tests__/battery-of-tests.ts
+++ b/src/auth/session/storage/__tests__/battery-of-tests.ts
@@ -1,4 +1,5 @@
 import {Session} from '../../session';
+import {sessionEqual} from '../../session-utils';
 import {SessionStorage} from '../../session_storage';
 
 export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
@@ -8,10 +9,14 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
     const session = new Session(sessionId, 'shop', 'state', false);
 
     await expect(storage.storeSession(session)).resolves.toBe(true);
-    await expect(storage.loadSession(sessionId)).resolves.toEqual(session);
+    expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
+      true,
+    );
 
     await expect(storage.storeSession(session)).resolves.toBe(true);
-    await expect(storage.loadSession(sessionId)).resolves.toEqual(session);
+    expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
+      true,
+    );
 
     await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
     await expect(storage.loadSession(sessionId)).resolves.toBeUndefined();
@@ -20,13 +25,27 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
     await expect(storage.deleteSession(sessionId)).resolves.toBe(true);
   });
 
+  it('can store sessions with unexpected fields', async () => {
+    const storage = await storageFactory();
+    const sessionId = 'test_session';
+    const session = new Session(sessionId, 'shop', 'state', true);
+    (session as any).someField = 'lol';
+
+    await expect(storage.storeSession(session)).resolves.toBe(true);
+    expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
+      true,
+    );
+  });
+
   it('can store and delete sessions with online tokens', async () => {
     const storage = await storageFactory();
     const sessionId = 'test_session';
     const session = new Session(sessionId, 'shop', 'state', true);
 
     await expect(storage.storeSession(session)).resolves.toBe(true);
-    await expect(storage.loadSession(sessionId)).resolves.toEqual(session);
+    expect(sessionEqual(await storage.loadSession(sessionId), session)).toBe(
+      true,
+    );
   });
 
   it('wrong ids return null sessions', async () => {

--- a/src/auth/session/storage/mysql.ts
+++ b/src/auth/session/storage/mysql.ts
@@ -110,6 +110,7 @@ export class MySQLSessionStorage implements SessionStorage {
           isOnline tinyint NOT NULL,
           scope varchar(255),
           expires integer,
+          onlineAccessInfo varchar(255),
           accessToken varchar(255)
         )
       `;

--- a/src/auth/session/storage/mysql.ts
+++ b/src/auth/session/storage/mysql.ts
@@ -109,6 +109,7 @@ export class MySQLSessionStorage implements SessionStorage {
           state varchar(255) NOT NULL,
           isOnline tinyint NOT NULL,
           scope varchar(255),
+          expires integer,
           accessToken varchar(255)
         )
       `;

--- a/src/auth/session/storage/postgresql.ts
+++ b/src/auth/session/storage/postgresql.ts
@@ -121,6 +121,7 @@ export class PostgreSQLSessionStorage implements SessionStorage {
           isOnline boolean NOT NULL,
           scope varchar(255),
           expires integer,
+          onlineAccessInfo varchar(255),
           accessToken varchar(255)
         )
       `;

--- a/src/auth/session/storage/postgresql.ts
+++ b/src/auth/session/storage/postgresql.ts
@@ -120,6 +120,7 @@ export class PostgreSQLSessionStorage implements SessionStorage {
           state varchar(255) NOT NULL,
           isOnline boolean NOT NULL,
           scope varchar(255),
+          expires integer,
           accessToken varchar(255)
         )
       `;

--- a/src/auth/session/storage/sqlite.ts
+++ b/src/auth/session/storage/sqlite.ts
@@ -88,7 +88,8 @@ export class SQLiteSessionStorage implements SessionStorage {
           isOnline integer NOT NULL,
           expires integer,
           scope varchar(255),
-          accessToken varchar(255)
+          accessToken varchar(255),
+          onlineAccessInfo varchar(255)
         )
       `;
       await this.query(query);

--- a/src/auth/session/storage/sqlite.ts
+++ b/src/auth/session/storage/sqlite.ts
@@ -85,7 +85,8 @@ export class SQLiteSessionStorage implements SessionStorage {
           id varchar(255) NOT NULL PRIMARY KEY,
           shop varchar(255) NOT NULL,
           state varchar(255) NOT NULL,
-          isOnline tinyint NOT NULL,
+          isOnline integer NOT NULL,
+          expires integer,
           scope varchar(255),
           accessToken varchar(255)
         )

--- a/src/auth/session/storage/sqlite.ts
+++ b/src/auth/session/storage/sqlite.ts
@@ -32,7 +32,7 @@ export class SQLiteSessionStorage implements SessionStorage {
 
     const query = `
       INSERT OR REPLACE INTO ${this.options.sessionTableName}
-      (${Object.keys(session).join(', ')})
+      (${entries.map(([key]) => key).join(', ')})
       VALUES (${entries.map(() => '?').join(', ')});
     `;
 


### PR DESCRIPTION
Augments the database adapters to store the expiry date and the user ID of the session token.

Note: I am actively omitting the users name and email address etc to avoid storing PII without the user potential realizing that.