### PR TITLE
Fix StatusCode on Invalid Signature

### DIFF
--- a/src/webhooks/registry.ts
+++ b/src/webhooks/registry.ts
@@ -428,7 +428,7 @@ const WebhooksRegistry: RegistryInterface = {
             );
           }
         } else {
-          statusCode = StatusCode.Forbidden;
+          statusCode = StatusCode.Unauthorized;
           responseError = new ShopifyErrors.InvalidWebhookError(
             `Could not validate request for topic ${topic}`,
           );


### PR DESCRIPTION
Return 401 Unauthorized instead of 403 Forbidden when the signature is invalid. 

This error was reported in our App submission. There should probably be something in the documentation specifying that you MUST return a 401.

### WHY are these changes introduced?

Applied with a new App and received an error stating that we must respond to an invalid Webhook request with a 401 but that
the application was responding with a 403

### WHAT is this pull request doing?

Change the response code on an invalid signature request from 403 to 401

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
