### PR TITLE
Add upcoming July22 API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add support for July 2022 API version [#409](https://github.com/Shopify/shopify-node-api/pull/409)
+
 ## [3.1.3] - 2022-06-08
 
 ### Fixes

--- a/src/base-types.ts
+++ b/src/base-types.ts
@@ -21,6 +21,7 @@ export enum ApiVersion {
   October21 = '2021-10',
   January22 = '2022-01',
   April22 = '2022-04',
+  July22 = '2022-07',
   Unstable = 'unstable',
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1726,9 +1726,9 @@ camelcase@^6.2.0:
   integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
 
 caniuse-lite@^1.0.30001280:
-  version "1.0.30001286"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz"
-  integrity sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ==
+  version "1.0.30001357"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001357.tgz"
+  integrity sha512-b+KbWHdHePp+ZpNj+RDHFChZmuN+J5EvuQUlee9jOQIUAdhv9uvAZeEtUeLAknXbkiu1uxjQ9NLp1ie894CuWg==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
### WHY are these changes introduced?

Version `2022-07` of the API is coming up, and we should support it in the library.

### WHAT is this pull request doing?

Adding the version, but not changing any defaults or removing older versions while they're still supported.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above
- [X] I have added/updated tests for this change
