### PR TITLE
📝 Fixed the getting started document's example code snippets

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -125,14 +125,14 @@ import querystring from 'querystring';
 import Shopify, { ApiVersion } from '@shopify/shopify-api';
 require('dotenv').config();
 
-const { API_KEY, API_SECRET_KEY, SCOPES, SHOP, HOST } = process.env
+const { API_KEY, API_SECRET_KEY, SCOPES, SHOP, HOST, HOST_SCHEME } = process.env;
 
 Shopify.Context.initialize({
   API_KEY,
   API_SECRET_KEY,
   SCOPES: [SCOPES],
   HOST_NAME: HOST.replace(/https?:\/\//, ""),
-  HOST_SCHEME: HOST.split("://")[0],
+  HOST_SCHEME,
   IS_EMBEDDED_APP: {boolean},
   API_VERSION: ApiVersion.{version} // all supported versions are available, as well as "unstable" and "unversioned"
 });
@@ -185,14 +185,14 @@ require('dotenv').config();
 
 const app = express();
 
-const { API_KEY, API_SECRET_KEY, SCOPES, SHOP, HOST } = process.env;
+const { API_KEY, API_SECRET_KEY, SCOPES, SHOP, HOST, HOST_SCHEME } = process.env;
 
 Shopify.Context.initialize({
   API_KEY,
   API_SECRET_KEY,
   SCOPES: [SCOPES],
   HOST_NAME: HOST.replace(/https?:\/\//, ""),
-  HOST_SCHEME: HOST.split("://")[0],
+  HOST_SCHEME,
   IS_EMBEDDED_APP: {boolean},
   API_VERSION: ApiVersion.{version} // all supported versions are available, as well as "unstable" and "unversioned"
 });


### PR DESCRIPTION
### WHY are these changes introduced?

In the old document, while initializing the Shopify Context, it wasn't using the `HOST_SCHEME` that we added to our .env file. Because of that, `beginAuth` function was returning a wrong redirect path.

#### Example of the error:
According the old document, our .env file was like that: 


```
SHOP={shop}.myshopify.com
API_KEY={API}
API_SECRET_KEY={API_SECRET}
SCOPES=write_products
HOST=www.ngrok.com
HOST_SCHEME=https
```

And our initialize part (index.js):

```
const { API_KEY, API_SECRET_KEY, SCOPES, SHOP, HOST } =
  process.env;

Shopify.Context.initialize({
  API_KEY,
  API_SECRET_KEY,
  SCOPES: [SCOPES],
  HOST_NAME: HOST.replace(/https?:\/\//, ""),
  HOST_SCHEME: HOST.split("://")[0], //This line was causing to the error!!!!
  IS_EMBEDDED_APP: false,
  API_VERSION: ApiVersion.April22, 
});
```

_www.ngrok.com_ was our `HOST`. So, in this case, `HOST.split("://")[0]` part was not working.

### WHAT is this pull request doing?

I fixed that error by changing the `HOST_SCHEME` parameter's value while initializing the Shopify Context.

## Type of change

- [ ✅ ] Patch: Bug (non-breaking change which fixes an issue)
- [ 🚫 ] Minor: New feature (non-breaking change which adds functionality)
- [ 🚫 ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ✅ ] I have added a changelog entry, prefixed by the type of change noted above
- [ 🚫 ] I have added/updated tests for this change
- [ ✅ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
