### PR TITLE
Include query body in API deprecation logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Return a 401 instead of 403 when webhooks fail validation [#425](https://github.com/Shopify/shopify-api-node/pull/425)
 - Add optional new methods `deleteSession` and `findSessionsByShop` to `SessionStorage`, with the corresponding implementations for the various session storage adapters [#418](https://github.com/Shopify/shopify-api-node/pull/418)
+- Include subset of query body in API deprecation logs [#426](https://github.com/Shopify/shopify-api-node/pull/426)
 
 ## [4.1.0] - 2022-07-14
 
@@ -26,25 +27,29 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [3.1.3] - 2022-06-08
 
 ### Fixes
+
 - Return instances of `Session` from session storages, not POJOs.
 
 ## [3.1.2] - 2022-06-07
 
 ### Added
+
 - Store user id and expiration date of online tokens
 
 ### Fixes
+
 - Properly parse a non-json HTTP response [#257](https://github.com/Shopify/shopify-api-node/issues/257)
 - Don’t create a SQLite DB file if the SQLite storage is not used.
-
 
 ## [3.1.0] - 2022-05-16
 
 ### Added
+
 - Support for specifying the URI scheme of the host [#385](https://github.com/Shopify/shopify-api-node/pull/385)
 - Add optional `saving` parameter to `serialize` of `Base` class - default is `false` and will include read-only attributes in returned object; `true` used for `save` when committing via API to Shopify.
 
 ### Fixed
+
 - Fixes [#363](https://github.com/Shopify/shopify-api-node/issues/363)
   - Webhooks `register` now checks for any attempt to register a GDPR topic (not done via API but by Partner Dashboard), provides an error message in response
   - For topics that don't exist, `register` checks the response from the initial API call for an `errors` field and returns accordingly

--- a/src/clients/http_client/__tests__/http_client.test.ts
+++ b/src/clients/http_client/__tests__/http_client.test.ts
@@ -567,6 +567,10 @@ describe('HTTP client', () => {
     const client = new HttpClient(domain);
     console.warn = jest.fn();
 
+    const postBody = {
+      query: 'some query',
+    };
+
     fetchMock.mockResponses(
       [
         JSON.stringify({
@@ -583,9 +587,7 @@ describe('HTTP client', () => {
       [
         JSON.stringify({
           message: 'Some deprecated post request',
-          body: {
-            query: 'some query',
-          },
+          body: postBody,
         }),
         {
           status: 200,
@@ -607,12 +609,13 @@ describe('HTTP client', () => {
     await client.post({
       path: '/url/path',
       type: DataType.JSON,
-      data: {query: 'some query'},
+      data: postBody,
     });
 
     expect(console.warn).toHaveBeenCalledWith('API Deprecation Notice:', {
       message: 'This API endpoint has been deprecated',
       path: 'https://test-shop.myshopify.io/url/path',
+      body: `${JSON.stringify(postBody)}...`,
     });
   });
 

--- a/src/clients/http_client/http_client.ts
+++ b/src/clients/http_client/http_client.ts
@@ -20,6 +20,12 @@ import {
   RequestReturn,
 } from './types';
 
+interface DeprecationInterface {
+  message: string | null;
+  path: string;
+  body?: string;
+}
+
 export class HttpClient {
   // 1 second
   static readonly RETRY_WAIT_TIME = 1000;
@@ -182,10 +188,18 @@ export class HttpClient {
           response.headers &&
           response.headers.has('X-Shopify-API-Deprecated-Reason')
         ) {
-          const deprecation = {
+          const deprecation: DeprecationInterface = {
             message: response.headers.get('X-Shopify-API-Deprecated-Reason'),
             path: url,
           };
+
+          if (options.body) {
+            // This can only be a string, since we're always converting the body before calling this method
+            deprecation.body = `${(options.body as string).substring(
+              0,
+              100,
+            )}...`;
+          }
 
           const depHash = crypto
             .createHash('md5')


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/cli/issues/156

Currently, we're logging deprecation notices, but for the GraphQL API, we don't get a lot of details - since every request lands in the same endpoint, there's no way to tell them apart.

### WHAT is this pull request doing?

Adding the first 100 characters from the body (if one exists) to help indicate which query is triggering the logs, to make it easier for developers to figure out where they're hitting deprecated fields.

```
API Deprecation Notice: {
  message: 'https://shopify.dev/api/usage/versioning#deprecation-practices',
  path: 'https://shop.myshopify.com/admin/api/2022-07/graphql.json',
  body: 'query products {\\n        products(first: 2) {\\n          nodes {\\n            title\\n            bodyHt...'
}
```

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change