### PR TITLE
Add KV session storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^3.14.1",
+    "@cloudflare/workers-types": "^3.16.0",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-node-resolve": "^14.1.0",

--- a/src/__tests__/jest_projects/session_storage.jest.config.mjs
+++ b/src/__tests__/jest_projects/session_storage.jest.config.mjs
@@ -1,7 +1,15 @@
 import baseConfig from './base.jest.config.mjs';
 
+import semver from 'semver';
+
+const ignorePaths = [];
+if (semver.lt(process.version, '15.0.0')) {
+  ignorePaths.push('src/session-storage/__tests__/kv.test.ts');
+}
+
 export default {
   ...baseConfig,
   displayName: 'session_storage',
   rootDir: '../../session-storage',
+  testPathIgnorePatterns: ignorePaths,
 };

--- a/src/session-storage/__tests__/kv-bucket-dummy-worker.ts
+++ b/src/session-storage/__tests__/kv-bucket-dummy-worker.ts
@@ -1,0 +1,1 @@
+// Dummy script just so we can create a Miniflare instance for the KV bucket

--- a/src/session-storage/__tests__/kv.test.ts
+++ b/src/session-storage/__tests__/kv.test.ts
@@ -1,0 +1,19 @@
+import {Miniflare} from 'miniflare';
+
+import {KVSessionStorage} from '../kv';
+
+import {batteryOfTests} from './battery-of-tests';
+
+describe('KVSessionStorage', () => {
+  let storage: KVSessionStorage | undefined;
+  beforeAll(async () => {
+    const mf = new Miniflare({
+      scriptPath: './src/session-storage/__tests__/kv-bucket-dummy-worker.ts',
+      kvNamespaces: ['KV_TEST_BUCKET'],
+    });
+
+    storage = new KVSessionStorage(await mf.getKVNamespace('KV_TEST_BUCKET'));
+  });
+
+  batteryOfTests(async () => storage!);
+});

--- a/src/session-storage/kv.ts
+++ b/src/session-storage/kv.ts
@@ -1,0 +1,92 @@
+import {SessionInterface} from '../session/types';
+import {SessionStorage} from '../session/session_storage';
+import {createSanitizeShop} from '../utils/shop-validator';
+import {sessionEntries, sessionFromEntries} from '../session/session-utils';
+
+export class KVSessionStorage extends SessionStorage {
+  private bucket: KVNamespace;
+
+  constructor(bucket?: KVNamespace | undefined) {
+    super();
+
+    if (bucket) {
+      this.setBucket(bucket);
+    }
+  }
+
+  public setBucket(bucket: KVNamespace) {
+    this.bucket = bucket;
+  }
+
+  public async storeSession(session: SessionInterface): Promise<boolean> {
+    await this.bucket.put(session.id, JSON.stringify(sessionEntries(session)));
+    await this.addShopIds(session.shop, [session.id]);
+    return true;
+  }
+
+  public async loadSession(id: string): Promise<SessionInterface | undefined> {
+    const sessionData = await this.bucket.get<[string, string | number][]>(
+      id,
+      'json',
+    );
+    return sessionData ? sessionFromEntries(sessionData) : undefined;
+  }
+
+  public async deleteSession(id: string): Promise<boolean> {
+    const session = await this.loadSession(id);
+    if (!session) {
+      return true;
+    }
+
+    await this.bucket.delete(id);
+    await this.removeShopIds(session.shop, [session.id]);
+    return true;
+  }
+
+  public async deleteSessions(ids: string[]): Promise<boolean> {
+    let result = true;
+    for (const id of ids) {
+      result = result && (await this.deleteSession(id));
+    }
+
+    return result;
+  }
+
+  public async findSessionsByShop(shop: string): Promise<SessionInterface[]> {
+    const cleanShop = createSanitizeShop(this.config)(shop, true)!;
+
+    const sessionIds = await this.bucket.get<string[]>(
+      this.getShopSessionIdsKey(cleanShop),
+      {
+        type: 'json',
+      },
+    );
+
+    if (!sessionIds) {
+      return [];
+    }
+
+    return Promise.all(
+      sessionIds.map(async (id) => (await this.loadSession(id))!),
+    );
+  }
+
+  private getShopSessionIdsKey(shop: string): string {
+    return `shop:${shop}`;
+  }
+
+  private async addShopIds(shop: string, ids: string[]) {
+    const key = this.getShopSessionIdsKey(shop);
+    const shopIds = (await this.bucket.get<string[]>(key, 'json')) ?? [];
+    await this.bucket.put(key, JSON.stringify([...shopIds, ...ids]));
+  }
+
+  private async removeShopIds(shop: string, ids: string[]) {
+    const key = this.getShopSessionIdsKey(shop);
+    const shopIds = (await this.bucket.get<string[]>(key, 'json')) ?? [];
+    await this.bucket.put(
+      key,
+      JSON.stringify(shopIds.filter((id) => !ids.includes(id))),
+    );
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
       "esnext.asynciterable"
     ],
     "typeRoots": ["./node_modules/@types"],
+    "types": ["@cloudflare/workers-types", "node", "jest"],
     "outDir": "./dist",
     "baseUrl": ".",
     "rootDir": "src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -432,10 +432,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cloudflare/workers-types@^3.14.1":
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.14.1.tgz#8927ad8aa4e4cdd42d25793148337ed04f927021"
-  integrity sha512-B1/plF62pt+H2IJHvApK8fdOJAVsvojvacuac8x8s+JIyqbropMyqNqHTKLm3YD8ZFLGwYeFTudU+PQ7vGvBdA==
+"@cloudflare/workers-types@^3.16.0":
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.16.0.tgz#011658ca3f9810373e0eb4a2b5d6cabe4848d8d6"
+  integrity sha512-gaBUSaKS65mN3iKZEgichbXYEmAa/pXkc5Gbt+1BptYphdGkj09ggdsiE4w8g0F/uI1g36QaTKrzVnBAWMipvQ==
 
 "@endemolshinegroup/cosmiconfig-typescript-loader@3.0.2":
   version "3.0.2"


### PR DESCRIPTION
### WHY are these changes introduced?

CF workers currently only have the option of using memory-based session storage, which is both brittle and probably won't work in a real worker environment. We need some storage strategy that works for workers.

### WHAT is this pull request doing?

Adding a storage option based on [KV](https://developers.cloudflare.com/workers/runtime-apis/kv/), which should make it a lot easier for apps to get started on workers.