### PR TITLE
Change body to rawBody for consistency

### DIFF
--- a/docs/migrating-to-v6.md
+++ b/docs/migrating-to-v6.md
@@ -656,7 +656,7 @@ Here are all the specific changes that we made to the `Utils` object:
 
    ```ts
    const response = await shopify.clients.graphqlProxy({
-     body: req.rawBody, // From my app
+     rawBody: req.rawBody, // From my app
      rawRequest: req,
      rawResponse: res,
    });

--- a/src/clients/graphql/__tests__/graphql_proxy.test.ts
+++ b/src/clients/graphql/__tests__/graphql_proxy.test.ts
@@ -54,7 +54,7 @@ describe('GraphQL proxy with session', () => {
       };
 
       const testResponse = await shopify.clients.graphqlProxy({
-        body: request.body!,
+        rawBody: request.body!,
         rawRequest: request,
       });
 
@@ -160,7 +160,7 @@ describe('GraphQL proxy', () => {
 
     await expect(
       shopify.clients.graphqlProxy({
-        body: '',
+        rawBody: '',
         rawRequest: request,
       }),
     ).rejects.toThrow(InvalidSession);
@@ -174,7 +174,7 @@ describe('GraphQL proxy', () => {
     };
     await expect(
       shopify.clients.graphqlProxy({
-        body: '',
+        rawBody: '',
         rawRequest: request,
       }),
     ).rejects.toThrow(SessionNotFound);

--- a/src/clients/graphql/graphql_proxy.ts
+++ b/src/clients/graphql/graphql_proxy.ts
@@ -8,7 +8,7 @@ import {createGraphqlClientClass} from './graphql_client';
 
 export function createGraphqlProxy(config: ConfigInterface) {
   return async ({
-    body,
+    rawBody,
     ...adapterArgs
   }: GraphqlProxyParams): Promise<RequestReturn> => {
     const session = await createGetCurrent(config)({
@@ -31,7 +31,7 @@ export function createGraphqlProxy(config: ConfigInterface) {
       accessToken: session.accessToken,
     });
     return client.query({
-      data: body,
+      data: rawBody,
     });
   };
 }

--- a/src/clients/graphql/types.ts
+++ b/src/clients/graphql/types.ts
@@ -4,5 +4,5 @@ import {PostRequestParams} from '../http_client/types';
 export type GraphqlParams = Omit<PostRequestParams, 'path' | 'type'>;
 
 export interface GraphqlProxyParams extends AdapterArgs {
-  body: string;
+  rawBody: string;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Webhooks' `process` takes `rawBody` whereas GraphQL Proxy takes `body` (inconsistent)

Fixes #547 

### WHAT is this pull request doing?

- Change `body` param to `rawBody`, to be consistent with webhooks `process`
- Update migration guide