### PR TITLE
Log translated webhook topic when not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 - [Patch] Validate content of host parameter using sanitizeShop regex [#634](https://github.com/Shopify/shopify-api-js/pull/634)
+- [Patch] Use the GraphQL format of webhook topics in the error message [#626](https://github.com/Shopify/shopify-api-js/pull/626)
 
 ## [6.0.1] - 2022-12-08
 

--- a/lib/webhooks/__tests__/utils.ts
+++ b/lib/webhooks/__tests__/utils.ts
@@ -25,7 +25,7 @@ export function headers({
   apiVersion = '2023-01',
   domain = 'shop1.myshopify.io',
   hmac = 'fake',
-  topic = 'PRODUCTS_CREATE',
+  topic = 'products/create',
   webhookId = '123456789',
   lowercase = false,
 }: {

--- a/lib/webhooks/process.ts
+++ b/lib/webhooks/process.ts
@@ -84,7 +84,7 @@ export function process(
           log.debug('No HTTP handlers found', loggingContext);
 
           response.statusCode = StatusCode.NotFound;
-          errorMessage = `No HTTP webhooks registered for topic ${topic}`;
+          errorMessage = `No HTTP webhooks registered for topic ${graphqlTopic}`;
         }
       } else {
         log.debug('Webhook validation failed', loggingContext);


### PR DESCRIPTION
### WHY are these changes introduced?

Part of #625 

Currently, we're using `topic` when throwing an error because a webhook handler was not found. While it isn't incorrect, we should be using `graphqlTopic` to show the `PRODUCTS_UPDATE` format rather than` products/update`, so that the error isn't misleading for callers.

### WHAT is this pull request doing?

Changing the variable we use for the error message to make the message consistent with the configuration.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
