### PR TITLE
Add host param content validation using sanitizeShop regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- [Patch] Validate content of host parameter using sanitizeShop regex [#634](https://github.com/Shopify/shopify-api-js/pull/634)
+
 ## [6.0.1] - 2022-12-08
 
 - [Patch] Auto-detect session type in auth callback, deprecate `isOnline` argument [#628](https://github.com/Shopify/shopify-api-js/pull/628)

--- a/lib/auth/decode-host.ts
+++ b/lib/auth/decode-host.ts
@@ -1,0 +1,7 @@
+export function decodeHost(host: string): string {
+  // eslint-disable-next-line no-warning-comments
+  // TODO Remove the Buffer.from call when dropping Node 14 support
+  return typeof atob === 'undefined'
+    ? Buffer.from(host, 'base64').toString()
+    : atob(host);
+}

--- a/lib/auth/get-embedded-app-url.ts
+++ b/lib/auth/get-embedded-app-url.ts
@@ -3,6 +3,7 @@ import {ConfigInterface} from '../base-types';
 import {abstractConvertRequest} from '../../runtime/http';
 import {sanitizeHost} from '../utils/shop-validator';
 
+import {decodeHost} from './decode-host';
 import {GetEmbeddedAppUrlParams} from './types';
 
 export function getEmbeddedAppUrl(config: ConfigInterface) {
@@ -37,13 +38,7 @@ export function getEmbeddedAppUrl(config: ConfigInterface) {
 export function buildEmbeddedAppUrl(config: ConfigInterface) {
   return (host: string): string => {
     sanitizeHost(config)(host, true);
-
-    // eslint-disable-next-line no-warning-comments
-    // TODO Remove the Buffer.from call when dropping Node 14 support
-    const decodedHost =
-      typeof atob === 'undefined'
-        ? Buffer.from(host, 'base64').toString()
-        : atob(host);
+    const decodedHost = decodeHost(host);
 
     return `https://${decodedHost}/apps/${config.apiKey}`;
   };


### PR DESCRIPTION
### WHY are these changes introduced?

Patches a potential phishing vulnerability (Node implementation of [this PR](https://github.com/Shopify/shopify_app/pull/1605).

### WHAT is this pull request doing?

`sanitizeHost` decodes the host parameter and runs `sanitizeShop` against it, to confirm it complies with one of the expected hostname URLs.

Also adds `shopify.com` as a valid domain for `sanitizeShop` - fixes Shopify/first-party-library-planning#516

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~ - not applicable
