### PR TITLE
Change inactive days to 14, as per ops doc

### DIFF
--- a/.github/workflows/close-waiting-for-response-issues.yml
+++ b/.github/workflows/close-waiting-for-response-issues.yml
@@ -13,7 +13,7 @@ jobs:
           actions: 'close-issues'
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: 'Waiting for Response'
-          inactive-day: 7
+          inactive-day: 14
           body: |
             We are closing this issue because we did not hear back regarding additional details we needed to resolve this issue. If the issue persists and you are able to provide the missing clarification we need, feel free to respond and reopen this issue.
 


### PR DESCRIPTION
### WHY are these changes introduced?

Waiting for response should be 14 days instead of 7.
