### PR TITLE
Fix node crypto module setup

### DIFF
--- a/.changeset/early-papayas-remain.md
+++ b/.changeset/early-papayas-remain.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Fix crypto module set up for node, so it doesn't break webpack apps

--- a/adapters/mock/index.ts
+++ b/adapters/mock/index.ts
@@ -1,9 +1,12 @@
+import crypto from 'crypto';
+
 import {
   setAbstractFetchFunc,
   setAbstractConvertRequestFunc,
   setAbstractConvertResponseFunc,
   setAbstractConvertHeadersFunc,
   setAbstractRuntimeString,
+  setCrypto,
 } from '../../runtime';
 
 import {
@@ -19,3 +22,4 @@ setAbstractConvertRequestFunc(mockConvertRequest);
 setAbstractConvertResponseFunc(mockConvertResponse);
 setAbstractConvertHeadersFunc(mockConvertHeaders);
 setAbstractRuntimeString(mockRuntimeString);
+setCrypto(crypto as any);

--- a/adapters/node/index.ts
+++ b/adapters/node/index.ts
@@ -1,3 +1,5 @@
+import crypto from 'crypto';
+
 import {
   setAbstractFetchFunc,
   setAbstractConvertRequestFunc,
@@ -5,6 +7,7 @@ import {
   setAbstractConvertResponseFunc,
   setAbstractConvertHeadersFunc,
   setAbstractRuntimeString,
+  setCrypto,
 } from '../../runtime';
 
 import {
@@ -22,3 +25,4 @@ setAbstractConvertIncomingResponseFunc(nodeConvertIncomingResponse);
 setAbstractConvertResponseFunc(nodeConvertAndSendResponse);
 setAbstractConvertHeadersFunc(nodeConvertAndSetHeaders);
 setAbstractRuntimeString(nodeRuntimeString);
+setCrypto(crypto as any);

--- a/runtime/crypto/crypto.ts
+++ b/runtime/crypto/crypto.ts
@@ -2,21 +2,15 @@
 
 // eslint-disable-next-line import/no-mutable-exports
 let cryptoVar: Crypto;
-if (typeof crypto === 'undefined') {
-  // CF worker will complain about a line reading require('crypto') even if it's never executed, as is the case here,
-  // so we create a hacky workaround to make it happy.
-  const cfWorkerWorkaround = 'crypto';
-  cryptoVar = require(cfWorkerWorkaround);
-} else {
+
+try {
   cryptoVar = crypto;
+} catch (_e) {
+  // This will fail for Node, but we're explicitly calling the below function to set it
 }
 
-export function setCrypto(_crypto: Crypto): void {
-  // deprecated
-  console.log(
-    '[shopify-api/WARNING] [Deprecated | 8.0.0] The setCrypto function is no longer necessary, and has been ' +
-      'deprecated. You should stop calling it from your adapter, as it will be removed in a future release.',
-  );
+export function setCrypto(crypto: Crypto): void {
+  cryptoVar = crypto;
 }
 
 export {cryptoVar as crypto};


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #889 

Currently, we're using a dynamic import to set up the internal `crypto` object for node, which makes it break with webpack.

### WHAT is this pull request doing?

Using the `setCrypto` call to safely set the value for node, but default it to the global `crypto` object for newer versions and other runtimes.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
