### PR TITLE
Add workingDirectories to ESLint config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,6 +5,7 @@ module.exports = {
   },
   extends: ['plugin:@shopify/typescript', 'plugin:@shopify/prettier'],
   ignorePatterns: ['dist/'],
+  workingDirectories: ['packages/*'],
   rules: {
     'no-console': 0,
     '@typescript-eslint/naming-convention': 0,


### PR DESCRIPTION
I was getting some squiggly lines in VSCode after the last improvements we made to the packages, and it seems that we were lacking the [`workingDirectories` config](https://github.com/Microsoft/vscode-eslint#settings-options) in our file.