### PR TITLE
Fix validations for store hosts starting with http

### DIFF
--- a/.changeset/curly-boxes-switch.md
+++ b/.changeset/curly-boxes-switch.md
@@ -1,0 +1,5 @@
+---
+"@shopify/graphql-client": patch
+---
+
+Fix GraphQL client validations for store hosts starting with http

--- a/packages/graphql-client/src/api-client-utilities/tests/validation.test.ts
+++ b/packages/graphql-client/src/api-client-utilities/tests/validation.test.ts
@@ -73,6 +73,26 @@ describe("validateDomainAndGetStoreUrl())", () => {
     });
     expect(domain).toEqual(`https://${domainOnly}`);
   });
+
+  it("returns a store url when a protocol-less store domain starting with http is provided", () => {
+    const domainOnly = "http-test-store.myshopify.io";
+
+    const domain = validateDomainAndGetStoreUrl({
+      client,
+      storeDomain: domainOnly,
+    });
+    expect(domain).toEqual(`https://${domainOnly}`);
+  });
+
+  it("returns a store url when a protocol-less store domain starting with https is provided", () => {
+    const domainOnly = "https-test-store.myshopify.io";
+
+    const domain = validateDomainAndGetStoreUrl({
+      client,
+      storeDomain: domainOnly,
+    });
+    expect(domain).toEqual(`https://${domainOnly}`);
+  });
 });
 
 describe("validateRequiredApiVersion()", () => {

--- a/packages/graphql-client/src/api-client-utilities/validations.ts
+++ b/packages/graphql-client/src/api-client-utilities/validations.ts
@@ -14,9 +14,10 @@ export function validateDomainAndGetStoreUrl({
 
     const trimmedDomain = storeDomain.trim();
 
-    const protocolUrl = trimmedDomain.startsWith("http")
-      ? trimmedDomain
-      : `https://${trimmedDomain}`;
+    const protocolUrl =
+      trimmedDomain.startsWith("http:") || trimmedDomain.startsWith("https:")
+        ? trimmedDomain
+        : `https://${trimmedDomain}`;
 
     const url = new URL(protocolUrl);
     url.protocol = "https";


### PR DESCRIPTION
### WHY are these changes introduced?

Some store hosts begin `http-` or `https-` which was being falsly picked up as having a protocol on this beginning.

Example error:

```
Admin API Client: a valid store domain ("https-www-markaz-app.myshopify.com") must be provided
```

### WHAT is this pull request doing?

Add tests for the example cases we've seen in production, and a fix whereby we test the string matches the full `http:` or `https:` protocol.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
