### PR TITLE
[Update][GraphQL Client] Remove Partial from ClientStreamResponse.data type

### DIFF
--- a/.changeset/shaggy-apes-argue.md
+++ b/.changeset/shaggy-apes-argue.md
@@ -1,0 +1,5 @@
+---
+"@shopify/graphql-client": patch
+---
+
+Remove `Partial` around the `ClientStreamResponse.data` type

--- a/packages/graphql-client/README.md
+++ b/packages/graphql-client/README.md
@@ -103,7 +103,7 @@ const client = createGraphQLClient({
 
 | Name        | Type                    | Description                                                                                                                                                                                         |
 | ----------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data?       | `Partial<TData> \| any` | Currently available data returned from the GraphQL API. If `TData` was provided to the function, the return type is `TData`, else it returns type `any`.                                         |
+| data?       | `TData \| any` | Currently available data returned from the GraphQL API. If `TData` was provided to the function, the return type is `TData`, else it returns type `any`.                                         |
 | errors?      | [`ResponseErrors`](#responseerrors)           | Errors object that contains any API or network errors that occured while fetching the data from the API. It does not include any `UserErrors`.                                                       |
 | extensions? | `Record<string, any>` | Additional information on the GraphQL response data and context. It can include the `context` object that contains the context settings used to generate the returned API response. |
 | hasNext     | `boolean`               | Flag to indicate whether the response stream has more incoming data                                                                                                                                 |

--- a/packages/graphql-client/src/graphql-client/types.ts
+++ b/packages/graphql-client/src/graphql-client/types.ts
@@ -32,8 +32,7 @@ export interface ClientResponse<TData = any> extends FetchResponseBody<TData> {
 }
 
 export interface ClientStreamResponse<TData = any>
-  extends Omit<ClientResponse<TData>, "data"> {
-  data?: Partial<TData>;
+  extends ClientResponse<TData> {
   hasNext: boolean;
 }
 

--- a/packages/storefront-api-client/README.md
+++ b/packages/storefront-api-client/README.md
@@ -124,7 +124,7 @@ const client = createStorefrontApiClient({
 
 | Name        | Type                    | Description                                                                                                                                                                                         |
 | ----------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data?       | `Partial<TData> \| any` | Currently available data returned from the Storefront API. If `TData` was provided to the function, the return type is `TData`, else it returns type `any`.                                         |
+| data?       | `TData \| any` | Currently available data returned from the Storefront API. If `TData` was provided to the function, the return type is `TData`, else it returns type `any`.                                         |
 | errors?      | [`ResponseErrors`](#responseerrors)           | Errors object that contains any API or network errors that occured while fetching the data from the API. It does not include any `UserErrors`.                                                       |
 | extensions? | `Record<string, any>` | Additional information on the GraphQL response data and context. It can include the `context` object that contains the context settings used to generate the returned API response. |
 | hasNext     | `boolean`               | Flag to indicate whether the response stream has more incoming data                                                                                                                                 |


### PR DESCRIPTION
### WHY are these changes introduced?
For consistency with `ClientResponse.data` and easier data consumption for client users, we are removing the `Partial` from the `ClientStreamResponse.data`.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [ ] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
