### PR TITLE
Fix recurring app charge currency type

### DIFF
--- a/.changeset/young-hotels-agree.md
+++ b/.changeset/young-hotels-agree.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-api": patch
+---
+
+Fixed an issue with the `RecurringApplicationCharge` REST resource currency type

--- a/packages/shopify-api/rest/admin/2022-10/recurring_application_charge.ts
+++ b/packages/shopify-api/rest/admin/2022-10/recurring_application_charge.ts
@@ -7,8 +7,6 @@ import {ResourcePath, ResourceNames} from '../../types';
 import {Session} from '../../../lib/session/session';
 import {ApiVersion} from '../../../lib/types';
 
-import {Currency} from './currency';
-
 interface FindArgs {
   session: Session;
   id: number | string;
@@ -32,9 +30,7 @@ interface CustomizeArgs {
 export class RecurringApplicationCharge extends Base {
   public static apiVersion = ApiVersion.October22;
 
-  protected static hasOne: {[key: string]: typeof Base} = {
-    "currency": Currency
-  };
+  protected static hasOne: {[key: string]: typeof Base} = {};
   protected static hasMany: {[key: string]: typeof Base} = {};
   protected static paths: ResourcePath[] = [
     {"http_method": "delete", "operation": "delete", "ids": ["id"], "path": "recurring_application_charges/<id>.json"},
@@ -124,7 +120,7 @@ export class RecurringApplicationCharge extends Base {
   public capped_amount: string | number | null;
   public confirmation_url: string | null;
   public created_at: string | null;
-  public currency: Currency | null | {[key: string]: any};
+  public currency: string | null;
   public id: number | null;
   public name: string | null;
   public price: string | number | null;

--- a/packages/shopify-api/rest/admin/2023-01/recurring_application_charge.ts
+++ b/packages/shopify-api/rest/admin/2023-01/recurring_application_charge.ts
@@ -7,8 +7,6 @@ import {ResourcePath, ResourceNames} from '../../types';
 import {Session} from '../../../lib/session/session';
 import {ApiVersion} from '../../../lib/types';
 
-import {Currency} from './currency';
-
 interface FindArgs {
   session: Session;
   id: number | string;
@@ -32,9 +30,7 @@ interface CustomizeArgs {
 export class RecurringApplicationCharge extends Base {
   public static apiVersion = ApiVersion.January23;
 
-  protected static hasOne: {[key: string]: typeof Base} = {
-    "currency": Currency
-  };
+  protected static hasOne: {[key: string]: typeof Base} = {};
   protected static hasMany: {[key: string]: typeof Base} = {};
   protected static paths: ResourcePath[] = [
     {"http_method": "delete", "operation": "delete", "ids": ["id"], "path": "recurring_application_charges/<id>.json"},
@@ -124,7 +120,7 @@ export class RecurringApplicationCharge extends Base {
   public capped_amount: string | number | null;
   public confirmation_url: string | null;
   public created_at: string | null;
-  public currency: Currency | null | {[key: string]: any};
+  public currency: string | null;
   public id: number | null;
   public name: string | null;
   public price: string | number | null;

--- a/packages/shopify-api/rest/admin/2023-04/recurring_application_charge.ts
+++ b/packages/shopify-api/rest/admin/2023-04/recurring_application_charge.ts
@@ -7,8 +7,6 @@ import {ResourcePath, ResourceNames} from '../../types';
 import {Session} from '../../../lib/session/session';
 import {ApiVersion} from '../../../lib/types';
 
-import {Currency} from './currency';
-
 interface FindArgs {
   session: Session;
   id: number | string;
@@ -32,9 +30,7 @@ interface CustomizeArgs {
 export class RecurringApplicationCharge extends Base {
   public static apiVersion = ApiVersion.April23;
 
-  protected static hasOne: {[key: string]: typeof Base} = {
-    "currency": Currency
-  };
+  protected static hasOne: {[key: string]: typeof Base} = {};
   protected static hasMany: {[key: string]: typeof Base} = {};
   protected static paths: ResourcePath[] = [
     {"http_method": "delete", "operation": "delete", "ids": ["id"], "path": "recurring_application_charges/<id>.json"},
@@ -124,7 +120,7 @@ export class RecurringApplicationCharge extends Base {
   public capped_amount: string | number | null;
   public confirmation_url: string | null;
   public created_at: string | null;
-  public currency: Currency | null | {[key: string]: any};
+  public currency: string | null;
   public id: number | null;
   public name: string | null;
   public price: string | number | null;

--- a/packages/shopify-api/rest/admin/2023-07/recurring_application_charge.ts
+++ b/packages/shopify-api/rest/admin/2023-07/recurring_application_charge.ts
@@ -7,8 +7,6 @@ import {ResourcePath, ResourceNames} from '../../types';
 import {Session} from '../../../lib/session/session';
 import {ApiVersion} from '../../../lib/types';
 
-import {Currency} from './currency';
-
 interface FindArgs {
   session: Session;
   id: number | string;
@@ -32,9 +30,7 @@ interface CustomizeArgs {
 export class RecurringApplicationCharge extends Base {
   public static apiVersion = ApiVersion.July23;
 
-  protected static hasOne: {[key: string]: typeof Base} = {
-    "currency": Currency
-  };
+  protected static hasOne: {[key: string]: typeof Base} = {};
   protected static hasMany: {[key: string]: typeof Base} = {};
   protected static paths: ResourcePath[] = [
     {"http_method": "delete", "operation": "delete", "ids": ["id"], "path": "recurring_application_charges/<id>.json"},
@@ -124,7 +120,7 @@ export class RecurringApplicationCharge extends Base {
   public capped_amount: string | number | null;
   public confirmation_url: string | null;
   public created_at: string | null;
-  public currency: Currency | null | {[key: string]: any};
+  public currency: string | null;
   public id: number | null;
   public name: string | null;
   public price: string | number | null;

--- a/packages/shopify-api/rest/admin/2023-10/recurring_application_charge.ts
+++ b/packages/shopify-api/rest/admin/2023-10/recurring_application_charge.ts
@@ -7,8 +7,6 @@ import {ResourcePath, ResourceNames} from '../../types';
 import {Session} from '../../../lib/session/session';
 import {ApiVersion} from '../../../lib/types';
 
-import {Currency} from './currency';
-
 interface FindArgs {
   session: Session;
   id: number | string;
@@ -32,9 +30,7 @@ interface CustomizeArgs {
 export class RecurringApplicationCharge extends Base {
   public static apiVersion = ApiVersion.October23;
 
-  protected static hasOne: {[key: string]: typeof Base} = {
-    "currency": Currency
-  };
+  protected static hasOne: {[key: string]: typeof Base} = {};
   protected static hasMany: {[key: string]: typeof Base} = {};
   protected static paths: ResourcePath[] = [
     {"http_method": "delete", "operation": "delete", "ids": ["id"], "path": "recurring_application_charges/<id>.json"},
@@ -124,7 +120,7 @@ export class RecurringApplicationCharge extends Base {
   public capped_amount: string | number | null;
   public confirmation_url: string | null;
   public created_at: string | null;
-  public currency: Currency | null | {[key: string]: any};
+  public currency: string | null;
   public id: number | null;
   public name: string | null;
   public price: string | number | null;

--- a/packages/shopify-api/rest/admin/2024-01/recurring_application_charge.ts
+++ b/packages/shopify-api/rest/admin/2024-01/recurring_application_charge.ts
@@ -7,8 +7,6 @@ import {ResourcePath, ResourceNames} from '../../types';
 import {Session} from '../../../lib/session/session';
 import {ApiVersion} from '../../../lib/types';
 
-import {Currency} from './currency';
-
 interface FindArgs {
   session: Session;
   id: number | string;
@@ -32,9 +30,7 @@ interface CustomizeArgs {
 export class RecurringApplicationCharge extends Base {
   public static apiVersion = ApiVersion.January24;
 
-  protected static hasOne: {[key: string]: typeof Base} = {
-    "currency": Currency
-  };
+  protected static hasOne: {[key: string]: typeof Base} = {};
   protected static hasMany: {[key: string]: typeof Base} = {};
   protected static paths: ResourcePath[] = [
     {"http_method": "delete", "operation": "delete", "ids": ["id"], "path": "recurring_application_charges/<id>.json"},
@@ -124,7 +120,7 @@ export class RecurringApplicationCharge extends Base {
   public capped_amount: string | number | null;
   public confirmation_url: string | null;
   public created_at: string | null;
-  public currency: Currency | null | {[key: string]: any};
+  public currency: string | null;
   public id: number | null;
   public name: string | null;
   public price: string | number | null;

--- a/packages/shopify-api/rest/admin/2024-04/recurring_application_charge.ts
+++ b/packages/shopify-api/rest/admin/2024-04/recurring_application_charge.ts
@@ -7,8 +7,6 @@ import {ResourcePath, ResourceNames} from '../../types';
 import {Session} from '../../../lib/session/session';
 import {ApiVersion} from '../../../lib/types';
 
-import {Currency} from './currency';
-
 interface FindArgs {
   session: Session;
   id: number | string;
@@ -32,9 +30,7 @@ interface CustomizeArgs {
 export class RecurringApplicationCharge extends Base {
   public static apiVersion = ApiVersion.April24;
 
-  protected static hasOne: {[key: string]: typeof Base} = {
-    "currency": Currency
-  };
+  protected static hasOne: {[key: string]: typeof Base} = {};
   protected static hasMany: {[key: string]: typeof Base} = {};
   protected static paths: ResourcePath[] = [
     {"http_method": "delete", "operation": "delete", "ids": ["id"], "path": "recurring_application_charges/<id>.json"},
@@ -124,7 +120,7 @@ export class RecurringApplicationCharge extends Base {
   public capped_amount: string | number | null;
   public confirmation_url: string | null;
   public created_at: string | null;
-  public currency: Currency | null | {[key: string]: any};
+  public currency: string | null;
   public id: number | null;
   public name: string | null;
   public price: string | number | null;


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #1325 

The `RecurringApplicationCharge` REST resource has a `currency` field, which was incorrectly typed as `Currency` (the resource). Instead, it should be a string.

### WHAT is this pull request doing?

Changing the type of that field to be a string.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change