### PR TITLE
Add repo merger banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# `@shopify/shopify-api-js`
+# This repo has been moved
+
+> [!IMPORTANT]
+> This repo has been merged with [`Shopify/shopify-app-js`](https://github.com/Shopify/shopify-app-js). All of the packages contained within this repo were copied over and will be maintained / released from there.
+>
+> If you have an issue or feature request, please create it in the new repository.
+
+## `@shopify/shopify-api-js`
 
 This mono-repo is a collection of Shopify's JavaScript API client libraries and utilities.
 


### PR DESCRIPTION
Now that the JS repos have been merged, we'll no longer be accepting issues / PRs here.

This PR adds a banner to inform folks that that's the case as soon as they enter the repo.

Preview: https://github.com/Shopify/shopify-api-js/blob/744af84beb7975ba682e0c97092d7494670224b7/README.md